### PR TITLE
Enable Ctrl-Left/Right on directories and archives...

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.py[cod]
+.idea

--- a/application/gui/input_dialog.py
+++ b/application/gui/input_dialog.py
@@ -563,7 +563,7 @@ class DirectoryCreateDialog(CreateDialog):
 class CopyDialog:
 	"""Dialog which will ask user for additional options before copying"""
 
-	def __init__(self, application, source_provider, destination_provider, path):
+	def __init__(self, application, source_provider, destination_provider, destination_path):
 		self._dialog = gtk.Dialog(parent=application)
 
 		self._application = application
@@ -589,7 +589,7 @@ class CopyDialog:
 		self.label_destination.set_use_markup(True)
 
 		self.entry_destination = gtk.Entry()
-		self.entry_destination.set_text(path)
+		self.entry_destination.set_text(destination_path)
 		self.entry_destination.set_editable(False)
 		self.entry_destination.connect('activate', self._confirm_entry)
 

--- a/application/plugin_base/item_list.py
+++ b/application/plugin_base/item_list.py
@@ -1685,18 +1685,7 @@ class ItemList(PluginBase):
 
 		# create a (e.g. local) provider as fallback in case we are opening an archive
 		if len(self._providers) == 0:
-			if '://' in path:
-				protocol, p = (path.split('://')[0], path)
-			else:
-				protocol, p = ('file', user.home)
-
-			Provider = self._parent.get_provider_by_protocol(protocol)
-			result = Provider(self, p)
-
-			# cache provider for later use
-			root_path = result.get_root_path(p)
-			self._providers[root_path] = result
-			self._current_provider = result
+			self._current_provider = self.create_provider(path, False)
 
 		# check if there is a provider for specified path
 		if path in self._providers:

--- a/application/plugin_base/item_list.py
+++ b/application/plugin_base/item_list.py
@@ -1726,7 +1726,7 @@ class ItemList(PluginBase):
 				p = path
 				while p != '/' and p != '':
 					mime_type = self._parent.associations_manager.get_mime_type(path=p)
-					if self._parent.is_archive_supported(mime_type):
+					if self._parent.is_archive_supported(mime_type) and not p.startswith('ftp://'):
 						result = self.create_provider(p, True)
 						break
 					p = os.path.dirname(p)

--- a/application/plugins/archive_support/zip_provider.py
+++ b/application/plugins/archive_support/zip_provider.py
@@ -215,10 +215,6 @@ class ZipProvider(Provider):
 		"""Get directory list."""
 		real_path = self._real_path(path, relative_to)
 
-		# update file cache
-		if len(self._cache) == 0:
-			self._update_cache()
-
 		# get file list
 		result = []
 		if real_path in self._cache:

--- a/application/plugins/archive_support/zip_provider.py
+++ b/application/plugins/archive_support/zip_provider.py
@@ -78,6 +78,7 @@ class ZipProvider(Provider):
 		"""Set archive file handle."""
 		Provider.set_archive_handle(self, handle)
 		self._zip_file = zipfile.ZipFile(self._handle, 'a')
+		self._update_cache()  # immediately needed when opening '/home/foo/bar.zip/subdir' on handle
 
 	def release_archive_handle(self):
 		"""Release archive handle when it's no longer needed."""

--- a/application/plugins/archive_support/zip_provider.py
+++ b/application/plugins/archive_support/zip_provider.py
@@ -106,19 +106,20 @@ class ZipProvider(Provider):
 
 	def remove_directory(self, path, recursive, relative_to=None):
 		"""Remove directory and optionally its content"""
-		pass
+		raise RuntimeError("Unsupported operation - remove_directory(path={0}, recursive={1}, relative_to={2})".format(path, recursive, relative_to))
 
 	def remove_file(self, path, relative_to=None):
 		"""Remove file"""
-		pass
+		raise RuntimeError("Unsupported operation - remove_file(path={0}, relative_to={1})".format(path, relative_to))
 
 	def create_file(self, path, mode=None, relative_to=None):
 		"""Create empty file with specified mode set"""
 		pass
+		raise RuntimeError("Unsupported operation - create_file(path={0})".format(path))
 
 	def create_directory(self, path, mode=None, relative_to=None):
 		"""Create directory with specified mode set"""
-		pass
+		raise RuntimeError("Unsupported operation - create_directory(path={0})".format(path))
 
 	def get_file_handle(self, path, mode, relative_to=None):
 		"""Open path in specified mode and return its handle"""
@@ -205,11 +206,11 @@ class ZipProvider(Provider):
 
 	def set_timestamp(self, path, access=None, modify=None, change=None, relative_to=None):
 		"""Set timestamp for specified path"""
-		pass
+		raise RuntimeError("Unsupported operation - set_timestamp(path={0})".format(path))
 
 	def rename_path(self, source, destination, relative_to=None):
 		"""Rename file/directory within parents path"""
-		pass
+		raise RuntimeError("Unsupported operation - rename_path(source={0}, destination={1}, relative_to={2})".format(source, destination, relative_to))
 
 	def list_dir(self, path, relative_to=None):
 		"""Get directory list."""

--- a/application/plugins/archive_support/zip_provider.py
+++ b/application/plugins/archive_support/zip_provider.py
@@ -12,7 +12,7 @@ class ZipProvider(Provider):
 	"""Provider for handling of ZIP archives."""
 
 	is_local = False
-	protocol = None
+	protocol = 'zip'
 	archives = (
 			'application/zip',
 			'application/jar',

--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -427,7 +427,7 @@ class FileList(ItemList):
 
 		is_dir = item_list.get_value(selected_iter, Column.IS_DIR)
 		is_parent = item_list.get_value(selected_iter, Column.IS_PARENT_DIR)
-		is_archive = self._parent.is_archive_supported(mime_type)
+		is_archive = self._parent.is_archive_supported(mime_type) and not selected_file.startswith('ftp://')
 
 		# preemptively create provider if selected item is archive
 		if not is_parent and is_archive and not self.provider_exists(selected_file):

--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -874,7 +874,8 @@ class FileList(ItemList):
 									self._parent,
 									source_provider,
 									destination_provider,
-									result[1]  # options from dialog
+									result[1],  # options from dialog
+									self.path
 								)
 
 			# set event queue
@@ -917,7 +918,8 @@ class FileList(ItemList):
 									self._parent,
 									source_provider,
 									destination_provider,
-									result[1]  # options from dialog
+									result[1],  # options from dialog
+									self.path
 								)
 
 			# set event queues

--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -6,6 +6,7 @@ import user
 import fnmatch
 import common
 import gobject
+import traceback
 
 from column_editor import FileList_ColumnEditor
 from gui.input_dialog import ApplicationSelectDialog
@@ -2010,7 +2011,8 @@ class FileList(ItemList):
 
 			except Exception as error:
 				# report error first
-				print 'Load directory error: ', error.message
+				print "Load directory error: {0} - path={1}".format(error.message, path)
+				traceback.print_exc()
 
 				# clear locks and exit
 				self._thread_active.clear()

--- a/application/plugins/file_list/local_monitor.py
+++ b/application/plugins/file_list/local_monitor.py
@@ -44,7 +44,7 @@ class LocalMonitor(Monitor):
 
 		else:
 			# invalid path, raise exception
-			raise MonitorError('Unable to create monitor. Invalid path!')
+			raise MonitorError('Unable to create monitor - Invalid path - path={0}'.format(path))
 
 	def _changed(self, monitor, path, other_path, event_type):
 		"""Handle GIO signal"""

--- a/application/tools/viewer.py
+++ b/application/tools/viewer.py
@@ -1,4 +1,6 @@
 import os
+import chardet
+import codecs
 import gtk
 import pango
 import gobject
@@ -176,6 +178,10 @@ class Viewer:
 		text_view.set_cursor_visible(True)
 		text_view.modify_font(font)
 
+		# try to detect file character encoding and convert to Unicode
+		encoding = chardet.detect(content)['encoding']
+		if encoding is not None:
+			content = codecs.decode(content, encoding)
 		text_view.get_buffer().set_text(content)
 
 		# add container to notebook


### PR DESCRIPTION
Enable Ctrl-Left/Right on directories and archives, open archives on startup as well

I tested:
-  Ctrl-Left/Right on file (this is unchanged) and directory (opens subdirectory on opposite side)
-  Ctrl-Left/Right on archive (e.g. ZIP file) - Sunflower opens it on opposite side
-  Ctrl-Left/Right on subdirectory in archive (e.g. ZIP file) - Sunflower opens it on opposite side

I tested that if a panel had a archive open (either top level in archive or sub directory in archive) at time of exit, Sunflower opens up the archive at the previous location again (or user.home if archive doesn't exist anymore)