### PR TITLE
Enable mnemonics in bookmark list

### DIFF
--- a/application/widgets/bookmarks_menu.py
+++ b/application/widgets/bookmarks_menu.py
@@ -96,6 +96,7 @@ class BookmarksMenu:
 		else:
 			menu_item = gtk.MenuItem()
 
+		menu_item.set_use_underline(True)
 		menu_item.set_label(label)
 		menu_item.connect('activate', callback, data)
 


### PR DESCRIPTION
Now user can mark letter of a bookmark with underscore to access it instantly via keyboard.