### PR TITLE
File list: Remove queue flushing from _add_item method. Fix MeanEYE/Sunflower#36

### DIFF
--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -1579,9 +1579,6 @@ class FileList(ItemList):
 
 			self._item_queue.append(data)
 
-			if len(self._item_queue) > 50:
-				self._flush_queue(parent)
-
 		except Exception as error:
 			print 'Error: {0} - {1}'.format(filename, str(error))
 

--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -1242,6 +1242,12 @@ class FileList(ItemList):
 
 		self._store.set_sort_func(self._sort_column, self._sort_list)
 		self._store.set_sort_column_id(self._sort_column, order)
+		
+		selection = self._item_list.get_selection()
+		item_list, iter_to_scroll = selection.get_selected()
+		if iter_to_scroll:
+			path_to_scroll = item_list.get_path(iter_to_scroll)
+			self._item_list.scroll_to_cell(path_to_scroll, None, True, 0.5)
 
 	def _clear_sort_function(self):
 		"""Clear sort settings"""
@@ -2003,12 +2009,6 @@ class FileList(ItemList):
 
 				# turn on sorting
 				self._apply_sort_function()
-
-			selection = self._item_list.get_selection()
-			item_list, iter_to_scroll = selection.get_selected()
-			if iter_to_scroll:
-				path_to_scroll = item_list.get_path(iter_to_scroll)
-				self._item_list.scroll_to_cell(path_to_scroll, None, True, 0.5)
 
 			# load emblems
 			self._load_emblems(parent, parent_path)

--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -1579,6 +1579,9 @@ class FileList(ItemList):
 
 			self._item_queue.append(data)
 
+			if len(self._item_queue) > 50:
+				self._flush_queue(parent)
+
 		except Exception as error:
 			print 'Error: {0} - {1}'.format(filename, str(error))
 

--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -583,7 +583,7 @@ class FileList(ItemList):
 			# select parent row
 			path = item_list.get_path(parent)
 			self._item_list.set_cursor(path)
-			self._item_list.scroll_to_cell(path)
+			self._item_list.scroll_to_cell(path, None, True, 0.5)
 
 		return True
 
@@ -1399,7 +1399,7 @@ class FileList(ItemList):
 				# iter is not last in the list
 				path = item_list.get_path(next_iter)
 				self._item_list.set_cursor(path)
-				self._item_list.scroll_to_cell(path)
+				self._item_list.scroll_to_cell(path, None, True, 0.5)
 
 			elif item_list.iter_parent(selected_iter) is not None:
 				# if iter is part of expanded directory advance through parent
@@ -1408,7 +1408,7 @@ class FileList(ItemList):
 				if next_iter is not None:
 					path = item_list.get_path(next_iter)
 					self._item_list.set_cursor(path)
-					self._item_list.scroll_to_cell(path)
+					self._item_list.scroll_to_cell(path, None, True, 0.5)
 
 		return True
 
@@ -1604,7 +1604,7 @@ class FileList(ItemList):
 
 					# set cursor position and scroll ti make it visible
 					self._item_list.set_cursor(path)
-					self._item_list.scroll_to_cell(path)
+					self._item_list.scroll_to_cell(path, None, True, 0.5)
 
 			# clear item queue
 			self._item_queue[:] = []
@@ -2004,6 +2004,12 @@ class FileList(ItemList):
 				# turn on sorting
 				self._apply_sort_function()
 
+			selection = self._item_list.get_selection()
+			item_list, iter_to_scroll = selection.get_selected()
+			if iter_to_scroll:
+				path_to_scroll = item_list.get_path(iter_to_scroll)
+				self._item_list.scroll_to_cell(path_to_scroll, None, True, 0.5)
+
 			# load emblems
 			self._load_emblems(parent, parent_path)
 
@@ -2169,7 +2175,7 @@ class FileList(ItemList):
 		and len(self._store) > 0:
 			path = self._store.get_path(self._store.get_iter_first())
 			self._item_list.set_cursor(path)
-			self._item_list.scroll_to_cell(path)
+			self._item_list.scroll_to_cell(path, None, True, 0.5)
 
 	def select_all(self, pattern=None, exclude_list=None):
 		"""Select all items matching pattern"""


### PR DESCRIPTION
Queue flushing in _add_item slowdown direcory loading. Anyway we flush queue just after _add_item call. So queue flushing in _add_item is unnecesary.