### PR TITLE
File list: Deactivate accelerators in quick search mode.

### DIFF
--- a/application/plugin_base/item_list.py
+++ b/application/plugin_base/item_list.py
@@ -823,7 +823,10 @@ class ItemList(PluginBase):
 		pass
 
 	def _start_search(self, key=None):
-		"""Shows quick search panel and starts searching"""
+		"""Shows quick search panel, deactivates accelerators and starts searching"""
+		for group in self._accelerator_groups:
+			group.deactivate()
+
 		self._search_panel.show()
 		self._search_entry.grab_focus()
 
@@ -832,10 +835,12 @@ class ItemList(PluginBase):
 			self._search_entry.set_position(len(key))
 
 	def _stop_search(self, widget=None, data=None):
-		"""Hide quick search panel and return focus to item list"""
+		"""Hide quick search panel, activate accelerators and return focus to item list"""
 		self._search_panel.hide()
 
 		if widget is not None:
+			for group in self._accelerator_groups:
+				group.activate(self._parent)
 			self._item_list.grab_focus()
 
 		return False


### PR DESCRIPTION
Greetings, MeanEYE.
I have a minor inconvenience with Sunflower. I've customized key bindings to use Vim keys for navigation (hjkl) and after that become unable to use the Quick Search in file list - the keys were interpreted as binded commands. So I've added accelerators deactivation calls in '_start_search' and '_stop_search' and now it works properly for me.

In a similar fashion it was implemented for command line: [main_window.py](https://github.com/MeanEYE/Sunflower/blob/082c90fad108b4b71fe8b81c532b2eb3dcde4233/application/gui/main_window.py#L1419).

And thank you for an awesome file manager btw.
