### PR TITLE
The dialog where you type in the location freezes on large directories over the network.

### DIFF
--- a/application/gui/main_window.py
+++ b/application/gui/main_window.py
@@ -2301,7 +2301,8 @@ class MainWindow(gtk.Window):
 					'show_expanders': False,
 					'hide_horizontal_scrollbar': False,
 					'breadcrumbs': 2,
-					'second_extension': False
+					'second_extension': False,
+					'disable_path_input': False
 				})
 
 		# create default operation options

--- a/application/gui/preferences/item_list.py
+++ b/application/gui/preferences/item_list.py
@@ -68,6 +68,7 @@ class ItemListOptions(SettingsPage):
 		self._checkbox_show_expanders = gtk.CheckButton(_('Show tree expanders'))
 		self._checkbox_hide_scrollbar = gtk.CheckButton(_('Hide horizontal scrollbar'))
 		self._checkbox_second_extension = gtk.CheckButton(_('Support second level extension'))
+		self._checkbox_disable_path_input = gtk.CheckButton(_('Disable path lookup when typing in the path location box'))
 
 		self._checkbox_row_hinting.connect('toggled', self._parent.enable_save)
 		self._checkbox_show_hidden.connect('toggled', self._parent.enable_save)
@@ -80,6 +81,7 @@ class ItemListOptions(SettingsPage):
 		self._checkbox_show_expanders.connect('toggled', self._parent.enable_save)
 		self._checkbox_hide_scrollbar.connect('toggled', self._parent.enable_save)
 		self._checkbox_second_extension.connect('toggled', self._parent.enable_save)
+		self._checkbox_disable_path_input.connect('toggled', self._parent.enable_save)
 
 		# bread crumbs type
 		hbox_breadcrumbs = gtk.HBox(False, 5)
@@ -374,6 +376,7 @@ class ItemListOptions(SettingsPage):
 		vbox_look_and_feel.pack_start(self._checkbox_show_hidden, False, False, 0)
 		vbox_look_and_feel.pack_start(self._checkbox_show_expanders, False, False, 0)
 		vbox_look_and_feel.pack_start(self._checkbox_hide_scrollbar, False, False, 0)
+		vbox_look_and_feel.pack_start(self._checkbox_disable_path_input, False, False, 0)
 		vbox_look_and_feel.pack_start(hbox_breadcrumbs, False, False, 5)
 		vbox_look_and_feel.pack_start(hbox_mode_format, False, False, 5)
 		vbox_look_and_feel.pack_start(hbox_grid_lines, False, False, 5)
@@ -662,6 +665,7 @@ class ItemListOptions(SettingsPage):
 		self._checkbox_show_expanders.set_active(section.get('show_expanders'))
 		self._checkbox_hide_scrollbar.set_active(section.get('hide_horizontal_scrollbar'))
 		self._checkbox_second_extension.set_active(section.get('second_extension'))
+		self._checkbox_disable_path_input.set_active(section.get('disable_path_input'))
 
 		search_modifier = section.get('search_modifier')
 		self._checkbox_control.set_active(search_modifier[0] == '1')
@@ -707,6 +711,7 @@ class ItemListOptions(SettingsPage):
 		section.set('show_expanders', self._checkbox_show_expanders.get_active())
 		section.set('hide_horizontal_scrollbar', self._checkbox_hide_scrollbar.get_active())
 		section.set('second_extension', self._checkbox_second_extension.get_active())
+		section.set('disable_path_input', self._checkbox_disable_path_input.get_active())
 
 		search_modifier = "%d%d%d" % (
 								self._checkbox_control.get_active(),

--- a/application/plugin_base/item_list.py
+++ b/application/plugin_base/item_list.py
@@ -94,6 +94,8 @@ class ItemList(PluginBase):
 		scrollbar_horizontal = self._container.get_hscrollbar()
 		scrollbar_horizontal.set_child_visible(not hide_scrollbar)
 
+		self.disable_path_input = section.get('disable_path_input')
+
 		# connect events
 		self._item_list.connect('button-press-event', self._handle_button_press)
 		self._item_list.connect('button-release-event', self._handle_button_press)
@@ -1571,7 +1573,10 @@ class ItemList(PluginBase):
 		path = self.path
 
 		# create dialog
-		dialog = PathInputDialog(self._parent)
+		if self.disable_path_input==True:
+			dialog = InputDialog(self._parent)
+		else:
+			dialog = PathInputDialog(self._parent)
 		dialog.set_title(_('Path entry'))
 		dialog.set_label(_('Navigate to:'))
 		dialog.set_text(path)
@@ -1750,6 +1755,8 @@ class ItemList(PluginBase):
 		hide_scrollbar = section.get('hide_horizontal_scrollbar')
 		scrollbar_horizontal = self._container.get_hscrollbar()
 		scrollbar_horizontal.set_child_visible(not hide_scrollbar)
+
+		self.disable_path_input = section.get('disable_path_input')
 
 		# change change sorting sensitivity
 		self._sort_case_sensitive = section.get('case_sensitive_sort')


### PR DESCRIPTION
If you have a large directory with lots of things in it.
It's better to type in the location of where you want to go instead of clicking on the folders cause that may take some time.
But with the PathInputDialog enabled, it'll try to read the large directory and give you suggestions which can freeze that dialog.  This is an option to disable that.