### PR TITLE
Changed MoveOperation to use Gio::File::move

### DIFF
--- a/application/operation.py
+++ b/application/operation.py
@@ -1039,7 +1039,7 @@ class MoveOperation(CopyOperation):
 
 		# move file
 		try:
-			self._source.rename_path(
+			self._source.move_path(
 								file_name,
 								os.path.join(self._destination_path, dest_file),
 								relative_to=source_path

--- a/application/plugin_base/provider.py
+++ b/application/plugin_base/provider.py
@@ -222,7 +222,7 @@ class Provider:
 		pass
 
 	def move_path(self, source, destination, relative_to=None):
-		"""Rename file/directory """
+		"""Move path on same file system to a different parent node """
 		pass
 
 	def rename_path(self, source, destination, relative_to=None):

--- a/application/plugin_base/provider.py
+++ b/application/plugin_base/provider.py
@@ -221,6 +221,10 @@ class Provider:
 		"""Instead of deleting, move path to the trash"""
 		pass
 
+	def move_path(self, source, destination, relative_to=None):
+		"""Rename file/directory """
+		pass
+
 	def rename_path(self, source, destination, relative_to=None):
 		"""Rename file/directory within parents path"""
 		pass

--- a/application/plugins/archive_support/zip_provider.py
+++ b/application/plugins/archive_support/zip_provider.py
@@ -207,7 +207,7 @@ class ZipProvider(Provider):
 		pass
 
 	def move_path(self, source, destination, relative_to=None):
-		"""Rename file/directory """
+		"""Move path on same file system to a different parent node """
 		pass
 
 	def rename_path(self, source, destination, relative_to=None):

--- a/application/plugins/archive_support/zip_provider.py
+++ b/application/plugins/archive_support/zip_provider.py
@@ -206,6 +206,10 @@ class ZipProvider(Provider):
 		"""Set timestamp for specified path"""
 		pass
 
+	def move_path(self, source, destination, relative_to=None):
+		"""Rename file/directory """
+		pass
+
 	def rename_path(self, source, destination, relative_to=None):
 		"""Rename file/directory within parents path"""
 		pass

--- a/application/plugins/file_list/gio_provider.py
+++ b/application/plugins/file_list/gio_provider.py
@@ -255,7 +255,7 @@ class GioProvider(Provider):
 				)
 
 	def move_path(self, source, destination, relative_to=None):
-		"""Move file/directory """
+		"""Move path on same file system to a different parent node """
 		real_source = self._real_path(source, relative_to)
 		gio.File(real_source).move(gio.File(destination))
 

--- a/application/plugins/file_list/gio_provider.py
+++ b/application/plugins/file_list/gio_provider.py
@@ -254,6 +254,11 @@ class GioProvider(Provider):
 					long(change)
 				)
 
+	def move_path(self, source, destination, relative_to=None):
+		"""Move file/directory """
+		real_source = self._real_path(source, relative_to)
+		gio.File(real_source).move(gio.File(destination))
+
 	def rename_path(self, source, destination, relative_to=None):
 		"""Rename file/directory within parents path"""
 		real_source = self._real_path(source, relative_to)

--- a/application/plugins/file_list/local_provider.py
+++ b/application/plugins/file_list/local_provider.py
@@ -203,6 +203,7 @@ class LocalProvider(Provider):
 		os.utime(real_path, (access, modify))
 
 	def move_path(self, source, destination, relative_to=None):
+		"""Move path on same file system to a different parent node """
 		return self.rename_path(source,destination,relative_to)
 
 	def rename_path(self, source, destination, relative_to=None):

--- a/application/plugins/file_list/local_provider.py
+++ b/application/plugins/file_list/local_provider.py
@@ -202,6 +202,9 @@ class LocalProvider(Provider):
 		real_path = self._real_path(path, relative_to)
 		os.utime(real_path, (access, modify))
 
+	def move_path(self, source, destination, relative_to=None):
+		return self.rename_path(source,destination,relative_to)
+
 	def rename_path(self, source, destination, relative_to=None):
 		"""Rename file/directory within parents path"""
 		if relative_to is None:


### PR DESCRIPTION
Fixes #95 
Use Gio::File::move instead of set_display_name when moving a file.