### PR TITLE
Gio archive mounter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *.py[cod]
+.idea

--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -1966,8 +1966,13 @@ class FileList(ItemList):
 		# cache objects and settings
 		show_hidden = self._parent.options.section('item_list').get('show_hidden')
 
+		# create temp path for comparison as root paths are maintained without trailing slash
+		path_without_trailing_slash = path
+		if path != '/' and path[-1] == '/':
+			path_without_trailing_slash = path[:-1]
+
 		# add parent option for parent directory
-		if path != self.get_provider().get_root_path(path):
+		if path_without_trailing_slash != self.get_provider().get_root_path(path):
 			if parent is None:
 				self._store.append(parent, (
 								os.path.pardir,

--- a/application/plugins/file_list/gio_provider.py
+++ b/application/plugins/file_list/gio_provider.py
@@ -445,3 +445,32 @@ class DavsProvider(GioProvider):
 		return (
 			Support.SYSTEM_SIZE,
 		)
+
+class ArchiveProvider(GioProvider):
+	is_local = True
+	protocol = 'archive'
+
+	def get_protocol_icon(self):
+		"""Return protocol icon name"""
+		return 'drive-removable-media'
+
+	def get_support(self):
+		"""Return supported options by provider"""
+		return ()
+
+	def get_root_path(self, path):
+		"""Get root for specified path"""
+		result = None
+
+		# try to get mount
+		mount = gio.File(path).find_enclosing_mount()
+
+		# get root directory from mount
+		if mount is not None:
+			result = mount.get_root().get_uri()
+
+		# remove trailing slash
+		if result[-1] == os.path.sep:
+			result = result[:-1]
+
+		return result # don't unquote() result for archive:// URIs

--- a/application/plugins/file_list/local_monitor.py
+++ b/application/plugins/file_list/local_monitor.py
@@ -44,7 +44,7 @@ class LocalMonitor(Monitor):
 
 		else:
 			# invalid path, raise exception
-			raise MonitorError('Unable to create monitor. Invalid path!')
+			raise MonitorError("Unable to create monitor on invalid path - path='{0}'".format(path))
 
 	def _changed(self, monitor, path, other_path, event_type):
 		"""Handle GIO signal"""

--- a/application/plugins/file_list/plugin.py
+++ b/application/plugins/file_list/plugin.py
@@ -1,7 +1,7 @@
 from file_list import FileList
 from trash_list import TrashList
 from gio_extension import SambaExtension, FtpExtension, DavExtension, SftpExtension
-from gio_provider import NetworkProvider, TrashProvider, DavProvider, DavsProvider
+from gio_provider import NetworkProvider, TrashProvider, DavProvider, DavsProvider, ArchiveProvider
 from gio_provider import SambaProvider, FtpProvider, SftpProvider
 from local_provider import LocalProvider
 
@@ -20,6 +20,7 @@ def register_plugin(application):
 	application.register_provider(TrashProvider)
 	application.register_provider(DavProvider)
 	application.register_provider(DavsProvider)
+	application.register_provider(ArchiveProvider)
 
 	# register mount manager extension
 	application.register_mount_manager_extension(SambaExtension)

--- a/application/widgets/bookmarks_menu.py
+++ b/application/widgets/bookmarks_menu.py
@@ -161,8 +161,8 @@ class BookmarksMenu:
 
 	def __open_selected(self, widget, path):
 		"""Open selected item in either active, or new tab"""
-		# unquote path before giving it to handler
-		if path is not None and '://' in path:
+		# unquote path before giving it to handler unless it is archive path which has loads of quoted data embedded
+		if path is not None and '://' in path and not path.startswith('archive://'):
 			data = path.split('://', 1)
 			data[1] = urllib.unquote(data[1])
 			path = '://'.join(data)


### PR DESCRIPTION
Add support for GVFS Archive Mounter mounts - this just handles already mounted archives or archives being mounted. Thet URIs are kind of long and ugly looking so a few additional lines are required not to corrupt them.

TODO/Notes
- shorten URI in notebook tab - these are too long for archive:// URIs 
- (more general) if GVFS mounts get umounted, we should try to remove them from any notebook item to avoid users still trying to use them