### PR TITLE
Fix for moving network files problem.

### DIFF
--- a/application/operation.py
+++ b/application/operation.py
@@ -641,7 +641,7 @@ class CopyOperation(Operation):
 
 	def _scan_directory(self, directory, relative_path=None):
 		"""Recursively scan directory and populate list"""
-		source_path = self._source_path if relative_path is None else os.path.join(self._source_path, relative_path)
+		source_path = self._source_path if relative_path is None else self._source._real_path(self._source_path,relative_path)
 		try:
 			# try to get listing from directory
 			item_list = self._source.list_dir(directory, relative_to=source_path)
@@ -697,7 +697,7 @@ class CopyOperation(Operation):
 
 	def _create_directory(self, directory, relative_path=None):
 		"""Create specified directory"""
-		source_path = self._source_path if relative_path is None else os.path.join(self._source_path, relative_path)
+		source_path = self._source_path if relative_path is None else self._source._real_path(self._source_path,relative_path)
 		file_stat = self._source.get_stat(directory, relative_to=source_path)
 		mode = file_stat.mode if self._options[Option.SET_MODE] else 0755
 
@@ -739,7 +739,7 @@ class CopyOperation(Operation):
 	def _copy_file(self, file_name, relative_path=None):
 		"""Copy file content"""
 		can_procede = True
-		source_path = self._source_path if relative_path is None else os.path.join(self._source_path, relative_path)
+		source_path = self._source_path if relative_path is None else self._source._real_path(self._source_path,relative_path)
 		dest_file = file_name
 		sh = None
 		dh = None
@@ -986,7 +986,7 @@ class MoveOperation(CopyOperation):
 
 	def _remove_path(self, path, item_list, relative_path=None):
 		"""Remove path"""
-		source_path = self._source_path if relative_path is None else os.path.join(self._source_path, relative_path)
+		source_path = self._source_path if relative_path is None else self._source._real_path(self._source_path, relative_path)
 		try:
 			# try removing specified path
 			self._source.remove_path(path, relative_to=source_path)
@@ -1015,7 +1015,7 @@ class MoveOperation(CopyOperation):
 	def _move_file(self, file_name, relative_path=None):
 		"""Move specified file using provider rename method"""
 		can_procede = True
-		source_path = self._source_path if relative_path is None else os.path.join(self._source_path, relative_path)
+		source_path = self._source_path if relative_path is None else self._source._real_path(self._source_path,relative_path)
 		dest_file = file_name
 
 		# check if destination file exists
@@ -1027,7 +1027,7 @@ class MoveOperation(CopyOperation):
 
 				# get new name if user specified
 				if options[OverwriteOption.RENAME]:
-					dest_file = os.path.join(
+					dest_file = self._destination._real_path(
 					                    os.path.dirname(file_name),
 					                    options[OverwriteOption.NEW_NAME]
 					                )
@@ -1039,9 +1039,9 @@ class MoveOperation(CopyOperation):
 
 		# move file
 		try:
-			self._source.rename_path(
+			self._source.move_path(
 								file_name,
-								os.path.join(self._destination_path, dest_file),
+								self._destination._real_path(dest_file,self._destination_path),
 								relative_to=source_path
 							)
 

--- a/application/plugin_base/provider.py
+++ b/application/plugin_base/provider.py
@@ -221,6 +221,10 @@ class Provider:
 		"""Instead of deleting, move path to the trash"""
 		pass
 
+	def move_path(self, source, destination, relative_to=None):
+		"""Move path on same file system to a different parent node """
+		pass
+
 	def rename_path(self, source, destination, relative_to=None):
 		"""Rename file/directory within parents path"""
 		pass

--- a/application/plugins/archive_support/zip_provider.py
+++ b/application/plugins/archive_support/zip_provider.py
@@ -206,6 +206,10 @@ class ZipProvider(Provider):
 		"""Set timestamp for specified path"""
 		pass
 
+	def move_path(self, source, destination, relative_to=None):
+		"""Move path on same file system to a different parent node """
+		pass
+
 	def rename_path(self, source, destination, relative_to=None):
 		"""Rename file/directory within parents path"""
 		pass

--- a/application/plugins/file_list/gio_provider.py
+++ b/application/plugins/file_list/gio_provider.py
@@ -1,5 +1,6 @@
 import os
 import gio
+import re
 
 from urllib import unquote
 from gio_wrapper import File
@@ -12,6 +13,16 @@ class GioProvider(Provider):
 	"""Generic provider for file systems supported by GIO"""
 	is_local = False
 	protocol = ''
+
+	def _real_path(self, path, relative_to=None):
+		"""Commonly used function to get real path"""
+		if relative_to is None:
+			return path
+		elif re.match('^[a-zA-Z]+://',path)!=None:
+			return path
+		else:
+			return os.path.join(relative_to,path)
+
 
 	def is_file(self, path, relative_to=None):
 		"""Test if given path is file"""
@@ -253,6 +264,11 @@ class GioProvider(Provider):
 					gio.FILE_ATTRIBUTE_TYPE_UINT64,
 					long(change)
 				)
+
+	def move_path(self, source, destination, relative_to=None):
+		"""Move path on same file system to a different parent node """
+		real_source = self._real_path(source, relative_to)
+		gio.File(real_source).move(gio.File(destination))
 
 	def rename_path(self, source, destination, relative_to=None):
 		"""Rename file/directory within parents path"""

--- a/application/plugins/file_list/local_provider.py
+++ b/application/plugins/file_list/local_provider.py
@@ -202,6 +202,10 @@ class LocalProvider(Provider):
 		real_path = self._real_path(path, relative_to)
 		os.utime(real_path, (access, modify))
 
+	def move_path(self, source, destination, relative_to=None):
+		"""Move path on same file system to a different parent node """
+		return self.rename_path(source,destination,relative_to)
+
 	def rename_path(self, source, destination, relative_to=None):
 		"""Rename file/directory within parents path"""
 		if relative_to is None:


### PR DESCRIPTION
When I try to move/copy a file from a network folder to another network folder, there is an error.

There're two types of paths.  A local path(ie. /tmp/xxx) and a URL path(ie. smb://xxx/yyy).

When you call os.path.join("smb://xxx/yyy","smb://xxx/zzz")
It becomes...
smb://xxx/yyysmb://xxx/zzz

This patch checks whether there is a xxx:// protocol in the 2nd path.  Not sure if I did the right thing here, maybe there is a better way.  The change is in _real_path()

This includes another previous pull request which is needed for it to work, sorry.
