### PR TITLE
Fix zip_provider handling odd ZIP files

### DIFF
--- a/application/plugins/archive_support/zip_provider.py
+++ b/application/plugins/archive_support/zip_provider.py
@@ -71,6 +71,9 @@ class ZipProvider(Provider):
 					type = file_type
 				)
 
+			if key_name not in self._cache:
+				self._cache[key_name] = []
+
 			self._cache[key_name].append((file_name, file_info))
 			self._file_list.append(info.filename)
 


### PR DESCRIPTION
This fixes zip_provider's handling odd ZIP files where files come before the directory that contains them (e.g. below unzip -t test.zip)

    testing: test/                    OK
    testing: test/.config/bar.txt     OK <-- comes before test/.config/
    testing: test/.config/foo.txt     OK <-- comes before test/.config/
    testing: test/.config/            OK
    testing: test/bar/                OK
    testing: test/foo/                OK
    testing: test/foo/bar2.txt        OK
    testing: test/foo/bar1.txt        OK
    testing: test/foo/bar10.txt       OK
    testing: test/.empty              OK

