### PR TITLE
Makefile: Untar archive to specified destination

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ export HELP
 define dist_install
 	@mkdir -p $(install_directory)
 	# untar archive
-	@cd $(build_directory); tar -xf $(file_path).tar
+	@tar -xf $(file_path).tar -C $(build_directory)
 	# install files
 	@install -Dm755 $(working_directory)/dist/sunflower "$(install_directory)/usr/bin/sunflower"
 	@install -d "$(install_directory)/usr/share/sunflower"


### PR DESCRIPTION
Target `dist-deb` was failing with untar error:

```
tar: .//build/sunflower-0.3-60.tar: Cannot open: No such file or directory
```

This error was caused by going into `$(build_directory)` and trying to untar `.//build/sunflower-0.3-60.tar` from there.

Obviously, this problem had place for `dist-rpm` target as well.

Changed target branch to `release`, original pull request #165.