### PR TITLE
Fix bug with resizing panel size when showing spinner.

### DIFF
--- a/application/gui/main_window.py
+++ b/application/gui/main_window.py
@@ -2312,7 +2312,8 @@ class MainWindow(gtk.Window):
 		self.window_options.create_section('main').update({
 					'geometry': '960x550',
 					'state': 0,
-					'hide_on_close': False
+					'hide_on_close': False,
+					"handle_position": 480,
 				})
 
 		# create default terminal options


### PR DESCRIPTION
This bug occurs on all new installations.
Steps to reprodyce:
1. delele window config ~/.config/sunflower/windows.json
2. run sunflower
3. change directory or calculate dir size
    when spinner wil be shown active panel will change its size and change back when the spinner will disappear
