### PR TITLE
Fix for GTK3 issues

### DIFF
--- a/application/gui/main_window.py
+++ b/application/gui/main_window.py
@@ -2080,7 +2080,7 @@ class MainWindow(Gtk.ApplicationWindow):
 		else:
 			# no data is specified so we try to process command entry
 			raw_command = self.command_edit.get_text()
-			self.command_edit.insert_text(raw_command)
+			self.command_edit.insert_text(raw_command, 0)
 			self.command_edit.set_text('')
 
 		handled = False

--- a/application/widgets/title_bar.py
+++ b/application/widgets/title_bar.py
@@ -109,6 +109,7 @@ class TitleBar:
 		self._hbox.pack_start(self._hbox_controls, False, False, 0)
 
 		self._container.add(self._hbox)
+		self._spinner_counter = 0
 
 	def __get_colors(self, normal_style=False):
 		"""Get copy of the style for current state"""


### PR DESCRIPTION
1) Fixes issue with command entry widget - apparently insert_text() needs an additional parameter now - tested by entering e.g. 'cd /home/username'

2) Fix for initialized variable error from Python further down when hitting line with "self._spinner_counter += 1"