### PR TITLE
Add Accessible names

### DIFF
--- a/application/gui/main_window.py
+++ b/application/gui/main_window.py
@@ -632,6 +632,7 @@ class MainWindow(Gtk.ApplicationWindow):
 		self._paned = Gtk.VPaned() if self.options.get('horizontal_split') else Gtk.HPaned()
 
 		self.left_notebook = Gtk.Notebook.new()
+		self.left_notebook.get_accessible().set_name('left_notebook')
 		self.left_notebook.set_scrollable(True)
 		self.left_notebook.connect('focus-in-event', self._transfer_focus)
 		self.left_notebook.connect('page-added', self._page_added)
@@ -639,6 +640,7 @@ class MainWindow(Gtk.ApplicationWindow):
 		self.left_notebook.set_group_name('panel')
 
 		self.right_notebook = Gtk.Notebook.new()
+		self.right_notebook.get_accessible().set_name('right_notebook')
 		self.right_notebook.set_scrollable(True)
 		self.right_notebook.connect('focus-in-event', self._transfer_focus)
 		self.right_notebook.connect('page-added', self._page_added)

--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -2299,6 +2299,7 @@ class FileList(ItemList):
 										"\n{1}\n\n{0}\n\nWould you like to retry?"
 									).format(error, path)
 								)
+			dialog.get_accessible().set_name('switch_dir_failed')
 			dialog.set_default_response(Gtk.ResponseType.YES)
 			result = dialog.run()
 			dialog.destroy()


### PR DESCRIPTION
I'm experimenting with some automated testing (using LDTP) and it would help a great deal if some of the widgets have predictable names/identifiers in the GTK widget tree. The way this is achieved is setting names on the GtkAccessible interface. There should be no impact at functionality.