### PR TITLE
Reworking changes around Mount Manager and GIO Extension

### DIFF
--- a/application/gui/properties_window.py
+++ b/application/gui/properties_window.py
@@ -252,7 +252,7 @@ class PropertiesWindow(Gtk.Window):
 
 		# get volume
 		try:
-			mount = Gio.File(self._path).find_enclosing_mount()
+			mount = Gio.File.new_for_commandline_arg(self._path).find_enclosing_mount()
 			volume_name = mount.get_name()
 
 		except Exception:
@@ -263,7 +263,7 @@ class PropertiesWindow(Gtk.Window):
 		self._entry_name.set_text(os.path.basename(self._path))
 		self._label_type.set_text('{0}\n{1}'.format(description, self._mime_type))
 		self._label_size.set_text(item_size)
-		self._label_location.set_text(os.path.dirname(os.path.abspath(self._path)))
+		self._label_location.set_text(os.path.dirname(self._path))
 		self._label_volume.set_text(volume_name)
 		self._label_accessed.set_text(item_a_date)
 		self._label_modified.set_text(item_m_date)
@@ -339,8 +339,8 @@ class PropertiesWindow(Gtk.Window):
 
 		# for remote file systems simply set owner and group
 		else:
-			self._list_owner.append((stat.user_id, stat.user_id))
-			self._list_group.append((stat.group_id, stat.group_id))
+			self._list_owner.append((str(stat.user_id), stat.user_id))
+			self._list_group.append((str(stat.group_id), stat.group_id))
 			self._combobox_owner.set_active(0)
 			self._combobox_group.set_active(0)
 

--- a/application/mounts.py
+++ b/application/mounts.py
@@ -21,13 +21,19 @@ class MountsManager:
 
 	def _populate_list(self):
 		"""Populate mount/volume list"""
+
+		mounts_added = []
+
 		# get list of volumes
 		for volume in self._volume_monitor.get_volumes():
 			self.window._add_volume(volume, startup=True)
+			mounts_added.append(volume.get_activation_root().get_uri())
 
 		# get list of mounted volumes
 		for mount in self._volume_monitor.get_mounts():
-			self._add_mount(self._volume_monitor, mount)
+			if mount.get_root().get_uri() not in mounts_added:
+				self._add_mount(self._volume_monitor, mount)
+				mounts_added.append(volume.get_activation_root().get_uri())
 
 		# update menus
 		self.window._menu_updated()
@@ -42,6 +48,10 @@ class MountsManager:
 		# if mount has volume, set mounted flag
 		if volume is not None:
 			self.window._volume_mounted(volume)
+
+		# this gets called twice on the back of some 'mount-added' events
+		if mount_uri in self._mounts:
+			return
 
 		# add mount to the list in Mount Manager window
 		self.window._notify_mount_add(mount_icon, mount.get_name(), mount_uri)
@@ -92,7 +102,7 @@ class MountsManager:
 
 	def _unmount_item_menu_callback(self, widget, data=None):
 		"""Event called by the unmount menu item or unmount button from manager"""
-		uri = widget.get_data('uri')
+		uri = widget.uri
 
 		if uri is not None:
 			self._unmount(self._mounts[uri])
@@ -112,7 +122,7 @@ class MountsManager:
 				self.window._volume_unmounted(volume)
 
 			# we can safely unmount
-			mount.unmount(self._unmount_finish)
+			mount.unmount(Gio.MountUnmountFlags.FORCE, None, self._unmount_finish, None)
 
 		else:
 			# print error
@@ -126,7 +136,7 @@ class MountsManager:
 			dialog.run()
 			dialog.destroy()
 
-	def _unmount_finish(self, mount, result):
+	def _unmount_finish(self, mount, result, user_data=None):
 		"""Callback for unmount events"""
 		mount.unmount_finish(result)
 

--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -2025,7 +2025,7 @@ class FileList(ItemList):
 			self._thread_active.clear()
 
 			while self._main_thread_lock.is_set():
-				Gtk.main_iteration(block=False)
+				Gtk.main_iteration_do(blocking=False)
 
 		# clear list
 		if clear_store:

--- a/application/plugins/find_file_extensions/contents.py
+++ b/application/plugins/find_file_extensions/contents.py
@@ -50,7 +50,8 @@ class ContentsFindFiles(FindExtension):
 
 		if file_type is FileType.REGULAR:
 			# get buffer
-			text = self._buffer.get_text(*self._buffer.get_bounds())
+			(start, end) = self._buffer.get_bounds()
+			text = self._buffer.get_text(start, end, True)
 
 			# try finding content in file
 			try:

--- a/application/plugins/find_file_extensions/default.py
+++ b/application/plugins/find_file_extensions/default.py
@@ -48,8 +48,7 @@ class DefaultFindFiles(FindExtension):
 		label_pattern = Gtk.Label(label=_('Search for:'))
 		label_pattern.set_alignment(0, 0.5)
 
-		self._entries = Gtk.ListStore(str)
-		self._entry_pattern = Gtk.ComboBox.new_with_model_and_entry(model=self._entries)
+		self._entry_pattern = Gtk.ComboBoxText.new_with_entry()
 		self._entry_pattern.connect('changed', self.__handle_pattern_change)
 
 		self._checkbox_case_sensitive = Gtk.CheckButton(_('Case sensitive'))
@@ -106,7 +105,7 @@ class DefaultFindFiles(FindExtension):
 		entries = self._options.get('patterns') or ['*']
 
 		for entry in entries:
-			self._entries.append((entry,))
+			self._entry_pattern.append_text(entry)
 
 		# select first entry
 		self._entry_pattern.handler_block_by_func(self.__handle_pattern_change)

--- a/application/widgets/bookmarks_menu.py
+++ b/application/widgets/bookmarks_menu.py
@@ -162,7 +162,7 @@ class BookmarksMenu:
 	def __open_selected(self, widget, path):
 		"""Open selected item in either active, or new tab"""
 		# unquote path before giving it to handler
-		if path is not None and '://' in path:
+		if path is not None and '://' in path and not path.startswith('archive://'):
 			data = path.split('://', 1)
 			data[1] = urllib.unquote(data[1])
 			path = '://'.join(data)


### PR DESCRIPTION
I have tested this while
- mounting/unmounting volumes from Nautilus
- mounting/unmounting using Mount Manager widget and the "Unmount" menu item
- getting file properties (right mouse click menu)
- starting file viewer (F3) on files

I've tried to cover loads of combinations around ftp, archive and MTP (cell phone) mounts.

A few lines may actually be "left overs" from adding MTP and Archive GIO provider support earlier.
