### PR TITLE
Fix missing translators in about_window.py

### DIFF
--- a/application/gui/about_window.py
+++ b/application/gui/about_window.py
@@ -70,6 +70,10 @@ class AboutWindow:
 		),
 	]
 
+	translators = [
+
+	]
+
 	def __init__(self, parent):
 		# create main window
 		self._dialog = Gtk.AboutDialog()


### PR DESCRIPTION
without translator being defined there will be an error further down...