### PR TITLE
Fix handling of file deletion error/retry

### DIFF
--- a/application/gui/input_dialog.py
+++ b/application/gui/input_dialog.py
@@ -1492,19 +1492,6 @@ class OperationError:
 		return code
 
 
-class QuestionOperationError(OperationError):
-	"""Operation error with modified buttons labels."""
-
-	def __init__(self, application):
-		OperationError.__init__(self, application)
-
-		button_no = self._dialog.get_widget_for_response(Gtk.ResponseType.NO)
-		button_yes = self._dialog.get_widget_for_response(Gtk.ResponseType.YES)
-
-		button_no.set_label(_('No'))
-		button_yes.set_label(_('Yes'))
-
-
 class CreateToolbarWidgetDialog:
 	"""Create widget persisten dialog."""
 

--- a/application/mounts.py
+++ b/application/mounts.py
@@ -27,7 +27,8 @@ class MountsManager:
 		# get list of volumes
 		for volume in self._volume_monitor.get_volumes():
 			self.window._add_volume(volume, startup=True)
-			mounts_added.append(volume.get_activation_root().get_uri())
+			if volume.get_activation_root() is not None:
+				mounts_added.append(volume.get_activation_root().get_uri())
 
 		# get list of mounted volumes
 		for mount in self._volume_monitor.get_mounts():

--- a/application/operation.py
+++ b/application/operation.py
@@ -5,7 +5,7 @@ from gi.repository import Gtk, GObject
 from threading import Thread, Event
 from Queue import Queue
 
-from gui.input_dialog import OverwriteFileDialog, OverwriteDirectoryDialog, OperationError, QuestionOperationError
+from gui.input_dialog import OverwriteFileDialog, OverwriteDirectoryDialog, OperationError
 from gui.operation_dialog import CopyDialog, MoveDialog, DeleteDialog, RenameDialog
 from gui.error_list import ErrorList
 from plugin_base.provider import Mode as FileMode, TrashError, Support as ProviderSupport
@@ -427,7 +427,7 @@ class Operation(Thread):
 		else:
 			# we are not in silent mode, ask user
 			def ask_user(queue):
-				dialog = QuestionOperationError(self._application)
+				dialog = OperationError(self._application)
 				dialog.set_message(_(
 						'There was a problem trashing specified path. '
 						'Would you like to try removing it instead?'


### PR DESCRIPTION
This should fix issues
#194 The crash during deleting a hidden folder .Trash-* from an external flash drive in Ubuntu 15.10
#197 A crash during deleting a folder without permissions

I removed QuestionOperationError. There were no sub classes and after wrapping (or removing) the unused Gtk.ResponseType.NO/YES code there was nothing left to keep.

The change to mounts.py fixes an error with mounted flash drives not being processed correctly on Sunflower startup.