### PR TITLE
Fixing issue 195 - launching files with # % etc in file name

### DIFF
--- a/application/associations.py
+++ b/application/associations.py
@@ -209,7 +209,7 @@ class AssociationManager:
 
 			if application is not None:
 				if application.supports_uris():
-					selection = map(lambda path: 'file://{0}'.format(path) if not path.startswith('file://') else path, selection)
+					selection = map(lambda path: 'file://{0}'.format(urllib.pathname2url(path)) if not path.startswith('file://') else path, selection)
 					application.launch_uris(selection)
 				else:
 					application.launch([Gio.File.new_for_path(path) for path in selection])


### PR DESCRIPTION
Fixing issue 195 - launching files with # % etc in file name.

This is using urllib to do the URI encoding but only if applicable ie. file gets launched with file:// URL.