### PR TITLE
Fix Quit menu item

### DIFF
--- a/application/gui/main_window.py
+++ b/application/gui/main_window.py
@@ -271,7 +271,7 @@ class MainWindow(Gtk.ApplicationWindow):
 						'name': 'quit_program',
 						'type': 'image',
 						'stock': Gtk.STOCK_QUIT,
-						'callback' : self._destroy,
+						'callback' : self._quit,
 						'path': '<Sunflower>/File/Quit'
 					},
 				)
@@ -793,6 +793,11 @@ class MainWindow(Gtk.ApplicationWindow):
 
 		# exit main loop
 		Gtk.main_quit()
+
+	def _quit(self, widget=None, data=None):
+		"""Trigger destory action from Quit menu item"""
+		if not self.emit('delete-event', Gdk.Event.new(Gdk.EventType.DELETE)):
+			self.destroy()
 
 	def _delete_event(self, widget, data=None):
 		"""Handle delete event"""


### PR DESCRIPTION
This fixes issue #182 - this seemed the only reliable way to close Sunflower from the menu. The change behaviour appears to be a consequence of the changed way the application is launched in the first place (combination of Gtk.Application and Gtk.ApplicationWindow in main.py)

Pressing Alt-F4 or clicking the windows [X] close icon is unaffected.
