### PR TITLE
Fix for Debian Jessie without GConf

### DIFF
--- a/application/main.py
+++ b/application/main.py
@@ -6,7 +6,6 @@ try:
 	# check if gtk is available
 	import gi
 	gi.require_version('Gtk', '3.0')
-	gi.require_version('GConf', '2.0')
 	gi.require_version('Notify', '0.7')
 
 except:

--- a/application/plugin_base/terminal.py
+++ b/application/plugin_base/terminal.py
@@ -3,9 +3,10 @@ import gi
 from gi.repository import Gtk, Gdk, Vte
 
 try:
-	from gi.repository import GConf as gconf
+	from gi.repository import GConf
+	gconf_loaded = True
 except:
-	gconf = None
+	gconf_loaded = False
 
 from plugin_base.plugin import PluginBase
 from accelerator_group import AcceleratorGroup
@@ -169,7 +170,7 @@ class Terminal(PluginBase):
 	def __set_system_font(self, client=None, *args, **kwargs):
 		"""Set system font to terminal"""
 
-		if gconf is None:
+		if gconf_loaded:
 			return
 
 		path = '/desktop/gnome/interface'
@@ -178,8 +179,8 @@ class Terminal(PluginBase):
 		if client is None:
 			if not hasattr(self._terminal, 'client'):
 				# client wasn't assigned to widget, get default one and set events
-				client = gconf.Client.get_default()
-				client.add_dir(path, gconf.ClientPreloadType.PRELOAD_NONE)
+				client = GConf.Client.get_default()
+				client.add_dir(path, GConf.ClientPreloadType.PRELOAD_NONE)
 				client.notify_add(key, self.__set_system_font)
 				self._terminal.client = client
 

--- a/application/plugin_base/terminal.py
+++ b/application/plugin_base/terminal.py
@@ -1,9 +1,11 @@
 import gi
 
-# require specific version of Vte
-gi.require_version('Vte', '2.90')
+from gi.repository import Gtk, Gdk, Vte
 
-from gi.repository import Gtk, Gdk, Vte, GConf
+try:
+	from gi.repository import GConf as gconf
+except:
+	gconf = None
 
 from plugin_base.plugin import PluginBase
 from accelerator_group import AcceleratorGroup
@@ -101,10 +103,17 @@ class Terminal(PluginBase):
 
 			# configure terminal widget
 			shape = section.get('cursor_shape')
+
+			# Since Vte 0.38 Vte.TerminalCursorShape has been renamed Vte.CursorShape
+			if hasattr(Vte, 'TerminalCursorShape'):
+				cursorshape = Vte.TerminalCursorShape
+			else:
+				cursorshape = Vte.CursorShape
+
 			shape_type = {
-					CursorShape.BLOCK: Vte.TerminalCursorShape.BLOCK,
-					CursorShape.IBEAM: Vte.TerminalCursorShape.IBEAM,
-					CursorShape.UNDERLINE: Vte.TerminalCursorShape.UNDERLINE
+					CursorShape.BLOCK: cursorshape.BLOCK,
+					CursorShape.IBEAM: cursorshape.IBEAM,
+					CursorShape.UNDERLINE: cursorshape.UNDERLINE
 				}
 			self._terminal.set_cursor_shape(shape_type[shape])
 
@@ -159,14 +168,18 @@ class Terminal(PluginBase):
 
 	def __set_system_font(self, client=None, *args, **kwargs):
 		"""Set system font to terminal"""
+
+		if gconf is None:
+			return
+
 		path = '/desktop/gnome/interface'
 		key = '{0}/monospace_font_name'.format(path)
 
 		if client is None:
 			if not hasattr(self._terminal, 'client'):
 				# client wasn't assigned to widget, get default one and set events
-				client = GConf.Client.get_default()
-				client.add_dir(path, GConf.ClientPreloadType.PRELOAD_NONE)
+				client = gconf.Client.get_default()
+				client.add_dir(path, gconf.ClientPreloadType.PRELOAD_NONE)
 				client.notify_add(key, self.__set_system_font)
 				self._terminal.client = client
 
@@ -377,11 +390,18 @@ class Terminal(PluginBase):
 
 			# apply cursor shape
 			shape = section.get('cursor_shape')
+
+			# Since Vte 0.38 Vte.TerminalCursorShape has been renamed Vte.CursorShape
+			if hasattr(Vte, 'TerminalCursorShape'):
+				cursorshape = Vte.TerminalCursorShape
+			else:
+				cursorshape = Vte.CursorShape
+
 			shape_type = {
-					CursorShape.BLOCK: Vte.CURSOR_SHAPE_BLOCK,
-					CursorShape.IBEAM: Vte.CURSOR_SHAPE_IBEAM,
-					CursorShape.UNDERLINE: Vte.CURSOR_SHAPE_UNDERLINE
-				}
+				CursorShape.BLOCK: cursorshape.BLOCK,
+				CursorShape.IBEAM: cursorshape.IBEAM,
+				CursorShape.UNDERLINE: cursorshape.UNDERLINE
+			}
 			self._terminal.set_cursor_shape(shape_type[shape])
 
 			# apply allow bold

--- a/application/plugin_base/terminal.py
+++ b/application/plugin_base/terminal.py
@@ -391,7 +391,7 @@ class Terminal(PluginBase):
 			# apply cursor shape
 			shape = section.get('cursor_shape')
 
-			# Since Vte 0.38 Vte.TerminalCursorShape has been renamed Vte.CursorShape
+			# since Vte 0.38 Vte.TerminalCursorShape has been renamed Vte.CursorShape
 			if hasattr(Vte, 'TerminalCursorShape'):
 				cursorshape = Vte.TerminalCursorShape
 			else:

--- a/application/plugins/system_terminal/plugin.py
+++ b/application/plugins/system_terminal/plugin.py
@@ -92,7 +92,7 @@ class SystemTerminal(Terminal):
 			'child_setup': None,
 			'child_setup_data': None }
 
-		# Note: Since VTE 0.38 fork_command_full has been renamed spawn_sync
+		# since VTE 0.38 fork_command_full has been renamed spawn_sync
 		if hasattr(self._terminal, 'fork_command_full'):
 			(result, self._pid) = self._terminal.fork_command_full(**command)
 		else:

--- a/application/plugins/system_terminal/plugin.py
+++ b/application/plugins/system_terminal/plugin.py
@@ -3,6 +3,8 @@ import user
 import shlex
 import subprocess
 
+from gi.repository import GLib, Vte
+
 from parameters import Parameters
 from plugin_base.terminal import Terminal, TerminalType
 
@@ -36,10 +38,10 @@ class SystemTerminal(Terminal):
 				os.environ['TERM'] = 'xterm-color'
 				os.environ['COLORTERM'] = 'gnome-terminal'
 
-				# fork default shell
-				self._terminal.connect('child-exited', self.__child_exited)
-				self._terminal.connect('status-line-changed', self._update_terminal_status)
-				self._terminal.connect('realize', self.__terminal_realized)
+			# fork default shell
+			self._terminal.connect('child-exited', self.__child_exited)
+			self._terminal.connect('status-line-changed', self._update_terminal_status)
+			self._terminal.connect('realize', self.__terminal_realized)
 
 		elif self._terminal_type == TerminalType.EXTERNAL:
 			# connect signals
@@ -80,12 +82,21 @@ class SystemTerminal(Terminal):
 	def __terminal_realized(self, widget, data=None):
 		"""Event called once terminal emulator is realized"""
 		shell_command = self._options.get('shell_command', os.environ['SHELL'])
-		arguments = self._options.get('arguments', [shell_command])
-		self._pid = self._terminal.fork_command(
-								command=shell_command,
-								argv=arguments,
-								directory=self.path
-							)
+
+		command = {
+			'pty_flags': Vte.PtyFlags.DEFAULT,
+			'working_directory': self.path,
+			'argv': self._options.get('arguments', [shell_command]),
+			'envv': [],
+			'spawn_flags': GLib.SpawnFlags.DO_NOT_REAP_CHILD,
+			'child_setup': None,
+			'child_setup_data': None }
+
+		# Note: Since VTE 0.38 fork_command_full has been renamed spawn_sync
+		if hasattr(self._terminal, 'fork_command_full'):
+			(result, self._pid) = self._terminal.fork_command_full(**command)
+		else:
+			(result, self._pid) = self._terminal.spawn_sync(**command)
 
 	def __child_exited(self, widget, data=None):
 		"""Handle child process termination"""


### PR DESCRIPTION
Fix for issues #177 - After GTK3 switch - Sunflower doesn't start on Debian Jessie due to missing GConf

I have made usage of GConf optional. It was used to get system font for Vte terminal. Vte terminal is working now too.