### PR TITLE
Fix for issues #229 - Fast media preview not working - changed window to get_window()

### DIFF
--- a/application/gui/preferences/associations.py
+++ b/application/gui/preferences/associations.py
@@ -136,7 +136,7 @@ class AssociationsOptions(SettingsPage):
 	def __get_menu_position(self, menu, button):
 		"""Get history menu position"""
 		# get coordinates
-		window_x, window_y = self._parent.window.get_position()
+		window_x, window_y = self._parent.get_window().get_position()
 		button_x, button_y = button.translate_coordinates(self._parent, 0, 0)
 		button_h = button.get_allocation().height
 

--- a/application/gui/preferences/item_list.py
+++ b/application/gui/preferences/item_list.py
@@ -431,7 +431,7 @@ class ItemListOptions(SettingsPage):
 	def __get_menu_position(self, menu, button):
 		"""Get history menu position"""
 		# get coordinates
-		window_x, window_y = self._parent.window.get_position()
+		window_x, window_y = self._parent.get_window().get_position()
 		button_x, button_y = button.translate_coordinates(self._parent, 0, 0)
 		button_h = button.get_allocation().height
 

--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -1229,7 +1229,7 @@ class FileList(ItemList):
 		tree_rect = self._item_list.get_visible_rect()
 
 		# grab window coordinates
-		window_x, window_y = self._parent.window.get_position()
+		window_x, window_y = self._parent.get_window().get_position()
 
 		# relative to tree
 		x, y = rect.x, rect.y + rect.height

--- a/application/plugins/rename_extensions/default.py
+++ b/application/plugins/rename_extensions/default.py
@@ -181,7 +181,7 @@ class DefaultRename(RenameExtension):
 	def __get_menu_position(self, menu, button):
 		"""Get history menu position"""
 		# get coordinates
-		window_x, window_y = self._parent.window.window.get_position()
+		window_x, window_y = self._parent.window.get_window().get_position()
 		button_x, button_y = button.translate_coordinates(self._parent.window, 0, 0)
 		button_h = button.get_allocation().height
 


### PR DESCRIPTION
I searched for get_position() calls and reviewed them. All affected lines in PR triggered a traceback on console before and went silent afterwards. 

Images are now displayed in fast media preview.