### PR TITLE
Fix for issues #223 - GTK3 - File property dialog box - Ownership not…

### DIFF
--- a/application/gui/properties_window.py
+++ b/application/gui/properties_window.py
@@ -612,7 +612,7 @@ class PropertiesWindow(Gtk.Window):
 		self._list_owner = Gtk.ListStore(str, int)
 		cell_owner = Gtk.CellRendererText()
 
-		self._combobox_owner = Gtk.ComboBox.new_with_model_and_entry(self._list_owner)
+		self._combobox_owner = Gtk.ComboBox.new_with_model(self._list_owner)
 		self._combobox_owner.connect('changed', self._ownership_changed)
 		self._combobox_owner.pack_start(cell_owner, True)
 		self._combobox_owner.add_attribute(cell_owner, 'text', 0)
@@ -623,7 +623,7 @@ class PropertiesWindow(Gtk.Window):
 		self._list_group = Gtk.ListStore(str, int)
 		cell_group = Gtk.CellRendererText()
 
-		self._combobox_group = Gtk.ComboBox.new_with_model_and_entry(self._list_group)
+		self._combobox_group = Gtk.ComboBox.new_with_model(self._list_group)
 		self._combobox_group.connect('changed', self._ownership_changed)
 		self._combobox_group.pack_start(cell_group, True)
 		self._combobox_group.add_attribute(cell_group, 'text', 0)


### PR DESCRIPTION
The only problem seemed to have been us creating a GtkComboBox with entry when in fact we did not add an entry.