### PR TITLE
Fix for issues #253 - Problems opening URL based filenames

### DIFF
--- a/application/associations.py
+++ b/application/associations.py
@@ -209,7 +209,7 @@ class AssociationManager:
 
 			if application is not None:
 				if application.supports_uris():
-					selection = map(lambda path: 'file://{0}'.format(urllib.pathname2url(path)) if not path.startswith('file://') else path, selection)
+					selection = map(lambda path: 'file://{0}'.format(urllib.pathname2url(path)) if path.startswith('/') else path, selection)
 					application.launch_uris(selection)
 				else:
 					application.launch([Gio.File.new_for_path(path) for path in selection])
@@ -263,7 +263,10 @@ class AssociationManager:
 			self._application.create_terminal_tab(active_object._notebook, options)
 
 		else:
-			subprocess.Popen(split_command, cwd=os.path.dirname(selection[0]))
+			cwd = None
+			if selection[0].startswith('/'):
+				cwd = os.path.dirname(selection[0])
+			subprocess.Popen(split_command, cwd=cwd)
 
 	def execute_file(self, path, provider=None):
 		"""Execute specified item properly."""

--- a/application/gui/input_dialog.py
+++ b/application/gui/input_dialog.py
@@ -29,7 +29,7 @@ class InputDialog:
 	use_header_bar = {'use_header_bar': True} if hasattr(Gtk.Dialog, 'get_header_bar') else {}
 
 	def __init__(self, application):
-		self._dialog = Gtk.Dialog(parent=application, **use_header_bar)
+		self._dialog = Gtk.Dialog(parent=application, **InputDialog.use_header_bar)
 
 		self._application = application
 


### PR DESCRIPTION
My test cases - for files in on ftp:// GIO mount and local disk
-     Open (double-click) files (txt and pdf files)
-     Open text files in external viewer (pressing F4 on txt files)
-     'Create file' from (right mouse click) context menu - while selecting 'Open file in editor'

Additionally
- archive:// mounts (from Archive Mounter): read-only but double-click/open + extern viwer (F4) is working on txt and pdf files
- mtp:// mounts seems to work too
