### PR TITLE
Fix for issues #228 - Externally touching a file doesn't change date …

### DIFF
--- a/application/plugins/file_list/file_list.py
+++ b/application/plugins/file_list/file_list.py
@@ -1825,10 +1825,14 @@ class FileList(ItemList):
 			file_stat = provider.get_stat(name, relative_to=self.path)
 
 			file_mode = file_stat.mode
+			file_date = file_stat.time_modify
 			formated_file_mode = common.format_mode(file_mode, self._mode_format)
+			formated_file_date = time.strftime(self._time_format, time.localtime(file_date))
 
 			self._store.set_value(found_iter, Column.MODE, file_mode)
+			self._store.set_value(found_iter, Column.TIME, file_date)
 			self._store.set_value(found_iter, Column.FORMATED_MODE, formated_file_mode)
+			self._store.set_value(found_iter, Column.FORMATED_TIME, formated_file_date)
 
 	def _change_title_text(self, text=None):
 		"""Change title label text and add free space display"""


### PR DESCRIPTION
Fix for issues #228 - Externally touching a file doesn't change date in file list 

Test cases are:
1) touch a file -> triggers MonitorSignals.ATTRIBUTE_CHANGED but this isn't updating last modify timestamp, "refreshing" directory picks up the change though
2) chmod on file-> handled correctly through MonitorSignals.ATTRIBUTE_CHANGED
3) run a 'cat > file' on command line, leave it open and occasionally input another line with dummy text and press enter -> handled correctly through MonitorSignals.CHANGED

2+3) work as before and in case 1) is now picking up changes modification time
