### PR TITLE
Version check: decode response before parsing data

### DIFF
--- a/sunflower/tools/version_check.py
+++ b/sunflower/tools/version_check.py
@@ -78,7 +78,8 @@ class VersionCheck:
 		try:
 			# get data from web
 			url_handler = urlopen(self.URL)
-			data = url_handler.read()
+			encoding = url_handler.headers.get_content_charset()
+			data = url_handler.read().decode(encoding)
 
 		finally:
 			decoder = JSONDecoder()


### PR DESCRIPTION
Fixes issue #334 .
Tested on Fedora 30 with Python 3.7.3