### PR TITLE
Archive support: fix issue with invalid timestamps

### DIFF
--- a/sunflower/plugins/archive_support/zip_provider.py
+++ b/sunflower/plugins/archive_support/zip_provider.py
@@ -60,8 +60,12 @@ class ZipProvider(Provider):
 				key_name, file_name = os.path.split(info.filename)
 				file_type = FileType.REGULAR
 
-			# prepate file timestamp
-			file_timestamp = time.mktime(datetime.datetime(*info.date_time).timetuple())
+			# prepare file timestamp
+			try:
+				file_timestamp = time.mktime(datetime.datetime(*info.date_time).timetuple())
+			except ValueError:
+				# set fallback timestamp for files with invalid date_time value
+				file_timestamp = 0
 
 			# prepare file info
 			file_info = FileInfo(


### PR DESCRIPTION
Basic fix for #336 . If timestamp generation errors out - set default timestamp value.
Not sure if setting timestamp to 0 is best idea, as different archive and file managers solves this issue in different ways:
mc - shows date 1979 12 31 00:00
FileRoller - shows date 1979 11 30 00:00
Total Commander (on windows) - does not display date for such files
unzip - shows date as 1980 00 00 00:00