### PR TITLE
Fixed copy path to clipboard error

### DIFF
--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -2669,7 +2669,7 @@ class MainWindow(Gtk.ApplicationWindow):
 
 	def set_clipboard_text(self, text):
 		"""Set text data to clipboard"""
-		self.clipboard.set_text(text)
+		self.clipboard.set_text(text, -1)
 
 	def set_clipboard_item_list(self, operation, uri_list):
 		"""Set clipboard to contain list of items


### PR DESCRIPTION
Copy path to clipboard works correctly now. Fixes #318 