### PR TITLE
Updated incorrect icon names

### DIFF
--- a/sunflower/gui/input_dialog.py
+++ b/sunflower/gui/input_dialog.py
@@ -591,7 +591,7 @@ class DeleteDialog:
 		button_yes.set_can_default(True)
 		button_no = Gtk.Button.new_with_label(_('No'))
 
-		button_queue = Gtk.Button.new_from_icon_name('stock_bottom', Gtk.IconSize.BUTTON)
+		button_queue = Gtk.Button.new_from_icon_name('go-bottom', Gtk.IconSize.BUTTON)
 		button_queue.set_always_show_image(True)
 		button_queue.set_label('None')
 

--- a/sunflower/plugins/file_list/trash_list.py
+++ b/sunflower/plugins/file_list/trash_list.py
@@ -22,7 +22,7 @@ class TrashList(FileList):
 		options = self._parent.options
 
 		# empty trash button
-		self._empty_button = Gtk.Button.new_from_icon_name('edittrash', Gtk.IconSize.MENU)
+		self._empty_button = Gtk.Button.new_from_icon_name('user-trash-full', Gtk.IconSize.MENU)
 		self._empty_button.set_focus_on_click(False)
 		self._empty_button.set_tooltip_text(_('Empty trash'))
 		self._empty_button.connect('clicked', self.empty_trash)


### PR DESCRIPTION
Update incorrect icon names: "Empty trash" in Trash can tab and operation queue select in delete dialog.