### PR TITLE
Prevent errors when edit command is executed on directories

### DIFF
--- a/sunflower/plugins/file_list/file_list.py
+++ b/sunflower/plugins/file_list/file_list.py
@@ -1598,7 +1598,7 @@ class FileList(ItemList):
 								)
 			dialog.run()
 			dialog.destroy()
-			return False
+			return True
 
 		if len(selection_list) > 0:
 			self._parent.associations_manager.edit_file(selection_list)

--- a/sunflower/plugins/file_list/file_list.py
+++ b/sunflower/plugins/file_list/file_list.py
@@ -1587,6 +1587,19 @@ class FileList(ItemList):
 		"""Abstract method to edit currently selected item"""
 		selection_list = self._get_selection_list(relative=False, files_only=True)
 
+		# display error message if selection has no files
+		if selection_list is None:
+			dialog = Gtk.MessageDialog(
+									widget,
+									Gtk.DialogFlags.DESTROY_WITH_PARENT,
+									Gtk.MessageType.INFO,
+									Gtk.ButtonsType.OK,
+									_('No files selected.')
+								)
+			dialog.run()
+			dialog.destroy()
+			return False
+
 		if len(selection_list) > 0:
 			self._parent.associations_manager.edit_file(selection_list)
 


### PR DESCRIPTION
Pressing F4 (or clicking view button) on directory and "go up" item was showing error in console. I've added error dialog similar to one in mc and Total Commander, to inform user that for edit command they have to select a file.