### PR TITLE
Viewer plugin: fix error opening empty text file

### DIFF
--- a/sunflower/tools/viewer.py
+++ b/sunflower/tools/viewer.py
@@ -192,7 +192,8 @@ class Viewer:
 		if encoding is not None:
 			content = codecs.decode(content, encoding)
 
-		text_view.get_buffer().set_text(content)
+		if len(content) > 0:
+			text_view.get_buffer().set_text(content)
 
 		# add container to notebook
 		container.add(text_view)


### PR DESCRIPTION
Fix for viewer plugin to allow opening 0 bytes text files without errors.