### PR TITLE
Plugins: Default Toolbar: add missing imports

### DIFF
--- a/sunflower/plugins/default_toolbar/bookmark_button.py
+++ b/sunflower/plugins/default_toolbar/bookmark_button.py
@@ -1,6 +1,6 @@
 import os
 
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 
 
 class Button(Gtk.ToolButton):

--- a/sunflower/plugins/default_toolbar/bookmarks_button.py
+++ b/sunflower/plugins/default_toolbar/bookmarks_button.py
@@ -1,4 +1,4 @@
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 
 
 class Button(Gtk.ToolButton):
@@ -23,4 +23,4 @@ class Button(Gtk.ToolButton):
 
 	def _clicked(self, widget, data=None):
 		"""Handle click"""
-		self._application.show_bookmarks_menu(widget=self)
+		self._application.show_bookmarks_menu()

--- a/sunflower/plugins/default_toolbar/home_directory_button.py
+++ b/sunflower/plugins/default_toolbar/home_directory_button.py
@@ -1,3 +1,5 @@
+import os
+
 from .bookmark_button import Button as BookmarkButton
 
 

--- a/sunflower/plugins/default_toolbar/parent_directory_button.py
+++ b/sunflower/plugins/default_toolbar/parent_directory_button.py
@@ -1,4 +1,4 @@
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 
 
 class Button(Gtk.ToolButton):

--- a/sunflower/plugins/default_toolbar/separator.py
+++ b/sunflower/plugins/default_toolbar/separator.py
@@ -1,4 +1,4 @@
-from gi.repository import Gtk
+from gi.repository import Gtk, GObject
 
 
 class Separator(Gtk.SeparatorToolItem):


### PR DESCRIPTION
Fixes #326 . While toolbar now functions without errors, fix revealed few more issues: item ordering does not work, problems with bookmarks menu popup. I'll open separate issues for those.