### PR TITLE
Mounts manager: Fixed mount open error

### DIFF
--- a/sunflower/mounts.py
+++ b/sunflower/mounts.py
@@ -138,7 +138,5 @@ class Volume(Location):
 		if mount:
 			root = mount.get_root()
 			result = root.get_uri()
-			root.unref()
 
 		return result
-


### PR DESCRIPTION
Fixes #360 . I'm pretty sure that Python handles variable unreferencing (https://mail.gnome.org/archives/python-hackers-list/2013-February/msg00002.html).