### PR TITLE
fix SyntaxWarning

### DIFF
--- a/sunflower/plugins/file_list/file_list.py
+++ b/sunflower/plugins/file_list/file_list.py
@@ -2057,7 +2057,7 @@ class FileList(ItemList):
 
 		selection = []
 		for file_name in self._get_selection_list():
-			if protocol is 'file':
+			if protocol == 'file':
 				file_name = '{0}://{1}'.format(protocol, file_name)
 			selection.append(file_name)
 


### PR DESCRIPTION
```
sunflower/plugins/file_list/file_list.py:2060: SyntaxWarning: "is" with a literal. Did you mean "=="?
```