### PR TITLE
fake clipboard for item copy/cut/paste

### DIFF
--- a/sunflower/clipboard.py
+++ b/sunflower/clipboard.py
@@ -1,0 +1,38 @@
+from gi.repository import Gtk, Gdk
+
+class Clipboard:
+    def __init__(self):
+        self._operation=None
+        self._uri_list=[]
+
+        self._gtk_clipboard=Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+        self._gtk_clipboard.connect('owner_change',self._owner_changed)
+
+    def _owner_changed(self,clipboard,ev):
+        self._clear_clipboard()
+
+    def _clear_clipboard(self):
+        self._operation=None
+        self._uri_list.clear()
+
+    def set_text(self,*args,**kwds):
+        return self._gtk_clipboard.set_text(*args,**kwds)
+
+    def set_with_data(self,operation,uri_list):
+        self._clear_clipboard()
+        self._operation=operation
+        self._uri_list[:]=uri_list
+
+    def wait_for_contents(self,*args,**kwds):
+        if self._operation is None:
+            return
+        return '\n'.join([self._operation]+self._uri_list)
+
+    def wait_for_text(self):
+        return self._gtk_clipboard.wait_for_text()
+
+    def wait_is_text_available(self):
+        return self._gtk_clipboard.wait_is_text_available()
+
+    def wait_is_uris_available(self):
+        return self._gtk_clipboard.wait_is_uris_available()

--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -42,6 +42,7 @@ from sunflower.tools.find_files import FindFiles
 from sunflower.tools.version_check import VersionCheck
 from sunflower.tools.disk_usage import DiskUsage
 from sunflower.config import Config
+from sunflower.clipboard import Clipboard
 
 # user interface imports
 from sunflower.gui.about_window import AboutWindow
@@ -130,7 +131,7 @@ class MainWindow(Gtk.ApplicationWindow):
 		self.user_plugin_path = None
 
 		# create a clipboard manager
-		self.clipboard = Gtk.Clipboard.get(Gdk.SELECTION_CLIPBOARD)
+		self.clipboard = Clipboard()
 
 		# load config
 		self.load_config()
@@ -2669,23 +2670,8 @@ class MainWindow(Gtk.ApplicationWindow):
 		uri_list - list of URIs
 
 		"""
-		targets = [
-				('x-special/gnome-copied-files', 0, 0),
-				("text/uri-list", 0, 0)
-			]
-		raw_data = '{0}\n'.format(operation) + '\n'.join(uri_list)
-
-		def get_func(clipboard, selection, info, data):
-			"""Handle request from application"""
-			target = selection.get_target()
-			selection.set(target, 8, raw_data)
-
-		def clear_func(clipboard, data):
-			"""Clear function"""
-			pass
-
 		# set clipboard and return result
-		return self.clipboard.set_with_data(targets, get_func, clear_func)
+		return self.clipboard.set_with_data(operation, uri_list)
 
 	def get_clipboard_text(self):
 		"""Get text from clipboard"""
@@ -2694,11 +2680,11 @@ class MainWindow(Gtk.ApplicationWindow):
 	def get_clipboard_item_list(self):
 		"""Get item list from clipboard"""
 		result = None
-		selection = self.clipboard.wait_for_contents('x-special/gnome-copied-files')
+		selection = self.clipboard.wait_for_contents()
 
 		# in case there is something to paste
 		if selection is not None:
-			data = selection.data.splitlines(False)
+			data = selection.splitlines(False)
 
 			operation = data[0]
 			uri_list = data[1:]


### PR DESCRIPTION
It is ***NOT*** a perfect solution.
Since https://gitlab.gnome.org/GNOME/gtk/issues/364 had been closed without any fix in gtk-3-24, it is the time to do something wiith the clipboard.

This PR provides a 'internal clipboard' to store the list of item(s), and return if required.
Following is the behavior definition:
1. Text copy/paste is not changed.
2. Any clipboard changing (including text copy by sunflower itself or text/data copy by other application) will reset the 'internal clipboard'.
3. Item copied by other application is not available to sunflower, and item copied by sunflower is not available to other application.
4. Item copy/cut/paste by sunflower only change the 'internal clipboard', and the 'real' clipboard is not touched (which may also contain text copied by sunflower).

This PR try to workaround #357.