### PR TITLE
select matched item after search closed

### DIFF
--- a/sunflower/plugin_base/item_list.py
+++ b/sunflower/plugin_base/item_list.py
@@ -798,10 +798,14 @@ class ItemList(PluginBase):
 
 	def _stop_search(self, widget=None, data=None):
 		"""Hide quick search panel and return focus to item list"""
+		selection = self._item_list.get_selection()
+		item_list, selected_iter = selection.get_selected()
 		self._search_panel.set_search_mode(False)
 
 		if widget is not None:
 			self._item_list.grab_focus()
+			if selected_iter is not None:
+				selection.select_iter(selected_iter)
 
 		return False
 


### PR DESCRIPTION
Keep 'selected' status on matched item after search panel closed.

It should has been selected, but unselected after search panel closed.
It seems that the text in search panel is selected before panel closed, which cause the item lost 'selected' status.

If nothing was selected, nothing will be selected.