### PR TITLE
correctly show context menu if nothing selected

### DIFF
--- a/sunflower/plugins/file_list/file_list.py
+++ b/sunflower/plugins/file_list/file_list.py
@@ -1138,6 +1138,9 @@ class FileList(ItemList):
 		item_list, selected_iter = selection.get_selected()
 		associations_manager = self._parent.associations_manager
 		menu_manager = self._parent.menu_manager
+		if selected_iter is None:
+			cursor_path, focus_column = self._item_list.get_cursor()
+			selected_iter = item_list.get_iter(cursor_path)
 
 		is_dir = item_list.get_value(selected_iter, Column.IS_DIR)
 		is_parent = item_list.get_value(selected_iter, Column.IS_PARENT_DIR)
@@ -1233,6 +1236,9 @@ class FileList(ItemList):
 		"""Positions menu properly for given row"""
 		selection = self._item_list.get_selection()
 		item_list, selected_iter = selection.get_selected()
+		if selected_iter is None:
+			cursor_path, focus_column = self._item_list.get_cursor()
+			selected_iter = item_list.get_iter(cursor_path)
 
 		# grab cell and tree rectangles
 		rect = self._item_list.get_cell_area(item_list.get_path(selected_iter), self._columns[0])


### PR DESCRIPTION
If nothing matched by quick search, nothing will selected.
It cause such a exception if try to open context menu by keybinding:
```
Traceback (most recent call last):
  File "/var/build/sunflower3/sunflower/accelerator_group.py", line 93, in _handle_activate
    result = callback_method(widget, label)
  File "/var/build/sunflower3/sunflower/plugin_base/item_list.py", line 1221, in _show_open_with_menu
    self._prepare_popup_menu()
  File "/var/build/sunflower3/sunflower/plugins/file_list/file_list.py", line 1147, in _prepare_popup_menu
    is_dir = item_list.get_value(selected_iter, Column.IS_DIR)
TypeError: Argument 1 does not allow None as a value
```

This PR try to fix this exception by setting the target of context menu to the 'cursor' item instead.