### PR TITLE
skip command entry after openwith menu and preference window keybinding

### DIFF
--- a/sunflower/gui/preferences_window.py
+++ b/sunflower/gui/preferences_window.py
@@ -127,6 +127,7 @@ class PreferencesWindow(Gtk.Window):
 
 		if tab_name is not None and tab_name in self._tab_names:
 			self._tabs.set_current_page(self._tab_names[tab_name])
+		return True
 
 	def _hide(self, widget=None, data=None):
 		"""Hide dialog"""

--- a/sunflower/plugin_base/item_list.py
+++ b/sunflower/plugin_base/item_list.py
@@ -1216,6 +1216,7 @@ class ItemList(PluginBase):
 
 		# if this method is called by Menu key data is actually event object
 		self._open_with_menu.popup(None, None, self._get_popup_menu_position, None, 1, 0)
+		return True
 
 	def _show_popup_menu(self, widget=None, data=None):
 		"""Show item menu"""


### PR DESCRIPTION
This PR stop keybinding handling after showing openwith menu and preference window, so command extry will not open togther with them.