### PR TITLE
fix gi import in keyring and notifications

### DIFF
--- a/sunflower/__main__.py
+++ b/sunflower/__main__.py
@@ -28,7 +28,6 @@ try:
 	# check if gtk is available
 	import gi
 	gi.require_version('Gtk', '3.0')
-	gi.require_version('Notify', '0.7')
 
 except:
 	# print error and die

--- a/sunflower/gui/preferences/display.py
+++ b/sunflower/gui/preferences/display.py
@@ -102,6 +102,7 @@ class DisplayOptions(SettingsPage):
 
 		self._checkbox_hide_window_on_minimize = Gtk.CheckButton(_('Hide operation window on minimize'))
 		self._checkbox_show_notifications = Gtk.CheckButton(_('Show notifications'))
+		self._checkbox_show_notifications.set_sensitive(self._application.notification_manager.available)
 		self._checkbox_network_path_completion = Gtk.CheckButton(_('Use path completion on non-local paths'))
 
 		self._checkbox_hide_window_on_minimize.connect('toggled', self._parent.enable_save)

--- a/sunflower/keyring.py
+++ b/sunflower/keyring.py
@@ -1,14 +1,15 @@
 from __future__ import absolute_import
 
-from gi.repository import Gtk, GObject
-from sunflower.gui.input_dialog import InputDialog, PasswordDialog
-
 
 try:
+	import gi
 	gi.require_version('GnomeKeyring', '1.0')
 	from gi.repository import GnomeKeyring as keyring
 except:
 	keyring = None
+else:
+	from gi.repository import Gtk, GObject
+	from sunflower.gui.input_dialog import InputDialog, PasswordDialog
 
 
 class EntryType:
@@ -40,6 +41,10 @@ class KeyringManager:
 			}
 
 	def __init__(self, application):
+		# initialize keyring
+		if not self.is_available():
+			return
+
 		self._application = application
 		self._info = None
 		self._timeout = None
@@ -48,9 +53,7 @@ class KeyringManager:
 		self._status_icon = Gtk.Image()
 		self._status_icon.show()
 
-		# initialize keyring
-		if self.is_available():
-			self.__initialize_keyring()
+		self.__initialize_keyring()
 
 	def __update_icon(self):
 		"""Update icon based on keyring status"""

--- a/sunflower/notifications.py
+++ b/sunflower/notifications.py
@@ -4,8 +4,9 @@ import os
 import sys
 
 try:
+	import gi
+	gi.require_version('Notify', '0.7')
 	from gi.repository import Notify
-
 except:
 	Notify = None
 
@@ -15,12 +16,16 @@ class NotificationManager:
 	methods to plugins and operations.
 	"""
 
+	available = Notify is not None
+
 	def __init__(self, application):
+		# initialize OS notification system
+		if not self.available:
+			return
+
 		self._application = application
 
-		# initialize OS notification system
-		if Notify is not None:
-			Notify.init('sunflower')
+		Notify.init('sunflower')
 
 		# decide which icon to use
 		if self._application.icon_manager.has_icon('sunflower'):
@@ -40,8 +45,8 @@ class NotificationManager:
 	def notify(self, title, text, icon=None):
 		"""Make system notification"""
 		if not self._application.options.get('show_notifications') \
-		or Notify is None:
-			return  # if notifications are disabled
+		or not self.available:
+			return  # if notifications are disabled or unavailable
 
 		if icon is None:  # make sure we show notification with icon
 			icon = self._default_icon

--- a/sunflower/notifications.py
+++ b/sunflower/notifications.py
@@ -44,8 +44,8 @@ class NotificationManager:
 
 	def notify(self, title, text, icon=None):
 		"""Make system notification"""
-		if not self._application.options.get('show_notifications') \
-		or not self.available:
+		if not self.available \
+		or not self._application.options.get('show_notifications'):
 			return  # if notifications are disabled or unavailable
 
 		if icon is None:  # make sure we show notification with icon


### PR DESCRIPTION
This PR does several things:
1. start without gir-notify will not failed.
2. only initialize widget in keyring if  gir-gnomekeyring is available.
3. grayout checkbox of notifications option if gir-notify is not available.