### PR TITLE
Fix issue with trash list file monitor

### DIFF
--- a/sunflower/plugin_base/item_list.py
+++ b/sunflower/plugin_base/item_list.py
@@ -1650,7 +1650,8 @@ class ItemList(PluginBase):
 			result = self.create_provider(path, False)
 
 		# cache current provider
-		self._current_provider = result
+		if self._current_provider is None:
+			self._current_provider = result
 
 		return result
 

--- a/sunflower/plugins/file_list/file_list.py
+++ b/sunflower/plugins/file_list/file_list.py
@@ -1625,7 +1625,6 @@ class FileList(ItemList):
 		# find starting point
 		if parent is None:
 			found_iter = self._store.get_iter_first()
-			found_iter = self._store.iter_next(found_iter)  # skip parent directory
 
 		elif self._store.iter_has_child(parent):
 			found_iter = self._store.iter_children(parent)
@@ -1782,15 +1781,6 @@ class FileList(ItemList):
 
 		if found_iter is not None:
 			iter_name = self._store.get_value(found_iter, Column.NAME)
-
-			# if currently hovered item was removed
-			if iter_name == selected_name:
-				next_iter = item_list.iter_next(selected_iter)
-
-				if next_iter is None:  # make sure we select something
-					next_iter = item_list[-2].iter
-
-				self._item_list.set_cursor(item_list.get_path(next_iter))
 
 			if item_list.get_value(found_iter, Column.IS_DIR):
 				self._dirs['count'] -= 1

--- a/sunflower/plugins/file_list/local_monitor.py
+++ b/sunflower/plugins/file_list/local_monitor.py
@@ -27,7 +27,10 @@ class LocalMonitor(Monitor):
 		if provider.exists(self._path):
 			try:
 				# create file/directory monitor
-				self._monitor = Gio.File.new_for_path(path).monitor(Gio.FileMonitorFlags.SEND_MOVED)
+				if (path == 'trash:///'):
+					self._monitor = Gio.File.new_for_uri(path).monitor(Gio.FileMonitorFlags.SEND_MOVED)
+				else:
+					self._monitor = Gio.File.new_for_path(path).monitor(Gio.FileMonitorFlags.SEND_MOVED)
 
 			except Exception as error:
 				raise MonitorError('Error creating monitor: {0}'.format(repr(error)))


### PR DESCRIPTION
My long overdue attempt to fix trash list file monitor, should fix #328 .
Had to disable provider caching, as it causes problems with trash list. Removed parent directory skipping, as some special directories like trash doesn't have row "go up". Removed manual cursor moving after removing item, as in GTK3 it sorts itself out. Finally, when creating new monitor for trash folder we need to use new_for_uri() function.