### PR TITLE
use nanoseconds in os.utime

### DIFF
--- a/sunflower/operation.py
+++ b/sunflower/operation.py
@@ -777,7 +777,7 @@ class CopyOperation(Operation):
 
 			return
 
-	def _set_timestamp(self, path, access_nanoseconds, modify_nanoseconds, change_nanoseconds):
+	def _set_timestamp(self, path, access_time_ns, modify_time_ns, change_time_ns):
 		"""Set timestamps for specified path"""
 		if not self._options[Option.SET_TIMESTAMP]: return
 
@@ -785,9 +785,9 @@ class CopyOperation(Operation):
 			# try setting timestamp
 			self._destination.set_timestamp(
 									path,
-									access_nanoseconds,
-									modify_nanoseconds,
-									change_nanoseconds,
+									access_time_ns,
+									modify_time_ns,
+									change_time_ns,
 									relative_to=self._destination_path
 								)
 
@@ -805,7 +805,7 @@ class CopyOperation(Operation):
 
 			# try to set timestamp again
 			if response == OperationError.RESPONSE_RETRY:
-				self._set_timestamp(path, access_nanoseconds, modify_nanoseconds, change_nanoseconds)
+				self._set_timestamp(path, access_time_ns, modify_time_ns, change_time_ns)
 
 			return
 
@@ -1061,9 +1061,9 @@ class CopyOperation(Operation):
 				self._set_owner(dest_file, file_stat.user_id, file_stat.group_id)
 				self._set_timestamp(
 								dest_file,
-								file_stat.time_access_nanoseconds,
-								file_stat.time_modify_nanoseconds,
-								file_stat.time_change_nanoseconds
+								file_stat.time_access_ns,
+								file_stat.time_modify_ns,
+								file_stat.time_change_ns
 							)
 
 				break

--- a/sunflower/operation.py
+++ b/sunflower/operation.py
@@ -1059,11 +1059,12 @@ class CopyOperation(Operation):
 				# set file parameters
 				self._set_mode(dest_file, file_stat.mode)
 				self._set_owner(dest_file, file_stat.user_id, file_stat.group_id)
+				# use nanosecond based timestamp
 				self._set_timestamp(
 								dest_file,
-								file_stat.time_access,
-								file_stat.time_modify,
-								file_stat.time_change
+								file_stat.time_access_ns,
+								file_stat.time_modify_ns,
+								file_stat.time_change_ns
 							)
 
 				break

--- a/sunflower/operation.py
+++ b/sunflower/operation.py
@@ -777,7 +777,7 @@ class CopyOperation(Operation):
 
 			return
 
-	def _set_timestamp(self, path, access_time_ns, modify_time_ns, change_time_ns):
+	def _set_timestamp(self, path, access_nanoseconds, modify_nanoseconds, change_nanoseconds):
 		"""Set timestamps for specified path"""
 		if not self._options[Option.SET_TIMESTAMP]: return
 
@@ -785,9 +785,9 @@ class CopyOperation(Operation):
 			# try setting timestamp
 			self._destination.set_timestamp(
 									path,
-									access_time_ns,
-									modify_time_ns,
-									change_time_ns,
+									access_nanoseconds,
+									modify_nanoseconds,
+									change_nanoseconds,
 									relative_to=self._destination_path
 								)
 
@@ -805,7 +805,7 @@ class CopyOperation(Operation):
 
 			# try to set timestamp again
 			if response == OperationError.RESPONSE_RETRY:
-				self._set_timestamp(path, access_time_ns, modify_time_ns, change_time_ns)
+				self._set_timestamp(path, access_nanoseconds, modify_nanoseconds, change_nanoseconds)
 
 			return
 
@@ -1061,9 +1061,9 @@ class CopyOperation(Operation):
 				self._set_owner(dest_file, file_stat.user_id, file_stat.group_id)
 				self._set_timestamp(
 								dest_file,
-								file_stat.time_access_ns,
-								file_stat.time_modify_ns,
-								file_stat.time_change_ns
+								file_stat.time_access_nanoseconds,
+								file_stat.time_modify_nanoseconds,
+								file_stat.time_change_nanoseconds
 							)
 
 				break

--- a/sunflower/operation.py
+++ b/sunflower/operation.py
@@ -777,7 +777,7 @@ class CopyOperation(Operation):
 
 			return
 
-	def _set_timestamp(self, path, access_time_ns, modify_time_ns, change_time_ns):
+	def _set_timestamp(self, path, access_time, modify_time, change_time):
 		"""Set timestamps for specified path"""
 		if not self._options[Option.SET_TIMESTAMP]: return
 
@@ -785,9 +785,9 @@ class CopyOperation(Operation):
 			# try setting timestamp
 			self._destination.set_timestamp(
 									path,
-									access_time_ns,
-									modify_time_ns,
-									change_time_ns,
+									access_time,
+									modify_time,
+									change_time,
 									relative_to=self._destination_path
 								)
 
@@ -805,7 +805,7 @@ class CopyOperation(Operation):
 
 			# try to set timestamp again
 			if response == OperationError.RESPONSE_RETRY:
-				self._set_timestamp(path, access_time_ns, modify_time_ns, change_time_ns)
+				self._set_timestamp(path, access_time, modify_time, change_time)
 
 			return
 
@@ -1061,9 +1061,9 @@ class CopyOperation(Operation):
 				self._set_owner(dest_file, file_stat.user_id, file_stat.group_id)
 				self._set_timestamp(
 								dest_file,
-								file_stat.time_access_ns,
-								file_stat.time_modify_ns,
-								file_stat.time_change_ns
+								file_stat.time_access,
+								file_stat.time_modify,
+								file_stat.time_change
 							)
 
 				break

--- a/sunflower/operation.py
+++ b/sunflower/operation.py
@@ -777,7 +777,7 @@ class CopyOperation(Operation):
 
 			return
 
-	def _set_timestamp(self, path, access_time, modify_time, change_time):
+	def _set_timestamp(self, path, access_time_ns, modify_time_ns, change_time_ns):
 		"""Set timestamps for specified path"""
 		if not self._options[Option.SET_TIMESTAMP]: return
 
@@ -785,9 +785,9 @@ class CopyOperation(Operation):
 			# try setting timestamp
 			self._destination.set_timestamp(
 									path,
-									access_time,
-									modify_time,
-									change_time,
+									access_time_ns,
+									modify_time_ns,
+									change_time_ns,
 									relative_to=self._destination_path
 								)
 
@@ -805,7 +805,7 @@ class CopyOperation(Operation):
 
 			# try to set timestamp again
 			if response == OperationError.RESPONSE_RETRY:
-				self._set_timestamp(path, access_time, modify_time, change_time)
+				self._set_timestamp(path, access_time_ns, modify_time_ns, change_time_ns)
 
 			return
 
@@ -1061,9 +1061,9 @@ class CopyOperation(Operation):
 				self._set_owner(dest_file, file_stat.user_id, file_stat.group_id)
 				self._set_timestamp(
 								dest_file,
-								file_stat.time_access,
-								file_stat.time_modify,
-								file_stat.time_change
+								file_stat.time_access_ns,
+								file_stat.time_modify_ns,
+								file_stat.time_change_ns
 							)
 
 				break

--- a/sunflower/plugin_base/provider.py
+++ b/sunflower/plugin_base/provider.py
@@ -29,9 +29,9 @@ FileInfoExtended = namedtuple(
 					'time_access',  # time of last access
 					'time_modify',  # time of last modification
 					'time_change',  # time of file creation / on win create time
-					'time_access_ns',  # time of last access in nanoseconds as an integer
-					'time_modify_ns',  # time of last modification in nanoseconds as an integer
-					'time_change_ns',  # time of file creation / on win create time in nanoseconds as an integer
+					'time_access_nanoseconds',  # time of last access in nanoseconds as an integer
+					'time_modify_nanoseconds',  # time of last modification in nanoseconds as an integer
+					'time_change_nanoseconds',  # time of file creation / on win create time in nanoseconds as an integer
 					'type',  # file type, constant from FileType class
 					'device',  # device inode resides on
 					'inode'  # inode number

--- a/sunflower/plugin_base/provider.py
+++ b/sunflower/plugin_base/provider.py
@@ -29,9 +29,9 @@ FileInfoExtended = namedtuple(
 					'time_access',  # time of last access
 					'time_modify',  # time of last modification
 					'time_change',  # time of file creation / on win create time
-					'time_access_nanoseconds',  # time of last access in nanoseconds as an integer
-					'time_modify_nanoseconds',  # time of last modification in nanoseconds as an integer
-					'time_change_nanoseconds',  # time of file creation / on win create time in nanoseconds as an integer
+					'time_access_ns',  # time of last access in nanoseconds as an integer
+					'time_modify_ns',  # time of last modification in nanoseconds as an integer
+					'time_change_ns',  # time of file creation / on win create time in nanoseconds as an integer
 					'type',  # file type, constant from FileType class
 					'device',  # device inode resides on
 					'inode'  # inode number

--- a/sunflower/plugin_base/provider.py
+++ b/sunflower/plugin_base/provider.py
@@ -29,6 +29,9 @@ FileInfoExtended = namedtuple(
 					'time_access',  # time of last access
 					'time_modify',  # time of last modification
 					'time_change',  # time of file creation / on win create time
+					'time_access_ns',  # time of last access in nanoseconds as an integer
+					'time_modify_ns',  # time of last modification in nanoseconds as an integer
+					'time_change_ns',  # time of file creation / on win create time in nanoseconds as an integer
 					'type',  # file type, constant from FileType class
 					'device',  # device inode resides on
 					'inode'  # inode number

--- a/sunflower/plugin_base/provider.py
+++ b/sunflower/plugin_base/provider.py
@@ -29,9 +29,6 @@ FileInfoExtended = namedtuple(
 					'time_access',  # time of last access
 					'time_modify',  # time of last modification
 					'time_change',  # time of file creation / on win create time
-					'time_access_ns',  # time of last access in nanoseconds as an integer
-					'time_modify_ns',  # time of last modification in nanoseconds as an integer
-					'time_change_ns',  # time of file creation / on win create time in nanoseconds as an integer
 					'type',  # file type, constant from FileType class
 					'device',  # device inode resides on
 					'inode'  # inode number

--- a/sunflower/plugins/file_list/local_provider.py
+++ b/sunflower/plugins/file_list/local_provider.py
@@ -136,6 +136,9 @@ class LocalProvider(Provider):
 							time_access = 0,
 							time_modify = 0,
 							time_change = 0,
+							time_access_ns = 0,
+							time_modify_ns = 0,
+							time_change_ns = 0,
 							type = FileType.INVALID,
 							device = 0,
 							inode = 0
@@ -183,6 +186,9 @@ class LocalProvider(Provider):
 						time_access = file_stat.st_atime,
 						time_modify = file_stat.st_mtime,
 						time_change = file_stat.st_ctime,
+						time_access_ns = file_stat.st_atime_ns,
+						time_modify_ns = file_stat.st_mtime_ns,
+						time_change_ns = file_stat.st_ctime_ns,
 						type = item_type,
 						device = file_stat.st_dev,
 						inode = file_stat.st_ino
@@ -206,9 +212,11 @@ class LocalProvider(Provider):
 		On Linux/Unix operating system we can't set metadata change timestamp
 		so we just ignore this part until other platforms are supported.
 
+		pay attention that access, modify should use nanosecond based timestamp
+
 		"""
 		real_path = self.real_path(path, relative_to)
-		os.utime(real_path, (access, modify))
+		os.utime(real_path, ns=(access, modify))
 
 	def move_path(self, source, destination, relative_to=None):
 		"""Move path on same file system to a different parent node """

--- a/sunflower/plugins/file_list/local_provider.py
+++ b/sunflower/plugins/file_list/local_provider.py
@@ -136,9 +136,6 @@ class LocalProvider(Provider):
 							time_access = 0,
 							time_modify = 0,
 							time_change = 0,
-							time_access_ns = 0,
-							time_modify_ns = 0,
-							time_change_ns = 0,
 							type = FileType.INVALID,
 							device = 0,
 							inode = 0
@@ -186,9 +183,6 @@ class LocalProvider(Provider):
 						time_access = file_stat.st_atime,
 						time_modify = file_stat.st_mtime,
 						time_change = file_stat.st_ctime,
-						time_access_ns = file_stat.st_atime_ns,
-						time_modify_ns = file_stat.st_mtime_ns,
-						time_change_ns = file_stat.st_ctime_ns,
 						type = item_type,
 						device = file_stat.st_dev,
 						inode = file_stat.st_ino
@@ -206,7 +200,7 @@ class LocalProvider(Provider):
 		real_path = self.real_path(path, relative_to)
 		os.chown(real_path, owner, group)
 
-	def set_timestamp(self, path, access_ns=None, modify_ns=None, change_ns=None, relative_to=None):
+	def set_timestamp(self, path, access=None, modify=None, change=None, relative_to=None):
 		"""Set timestamps for specified path
 
 		On Linux/Unix operating system we can't set metadata change timestamp
@@ -214,7 +208,7 @@ class LocalProvider(Provider):
 
 		"""
 		real_path = self.real_path(path, relative_to)
-		os.utime(real_path, ns=(access_ns, modify_ns))
+		os.utime(real_path, (access, modify))
 
 	def move_path(self, source, destination, relative_to=None):
 		"""Move path on same file system to a different parent node """

--- a/sunflower/plugins/file_list/local_provider.py
+++ b/sunflower/plugins/file_list/local_provider.py
@@ -136,9 +136,9 @@ class LocalProvider(Provider):
 							time_access = 0,
 							time_modify = 0,
 							time_change = 0,
-							time_access_nanoseconds = 0,
-							time_modify_nanoseconds = 0,
-							time_change_nanoseconds = 0,
+							time_access_ns = 0,
+							time_modify_ns = 0,
+							time_change_ns = 0,
 							type = FileType.INVALID,
 							device = 0,
 							inode = 0
@@ -186,9 +186,9 @@ class LocalProvider(Provider):
 						time_access = file_stat.st_atime,
 						time_modify = file_stat.st_mtime,
 						time_change = file_stat.st_ctime,
-						time_access_nanoseconds = file_stat.st_atime_ns,
-						time_modify_nanoseconds = file_stat.st_mtime_ns,
-						time_change_nanoseconds = file_stat.st_ctime_ns,
+						time_access_ns = file_stat.st_atime_ns,
+						time_modify_ns = file_stat.st_mtime_ns,
+						time_change_ns = file_stat.st_ctime_ns,
 						type = item_type,
 						device = file_stat.st_dev,
 						inode = file_stat.st_ino
@@ -206,7 +206,7 @@ class LocalProvider(Provider):
 		real_path = self.real_path(path, relative_to)
 		os.chown(real_path, owner, group)
 
-	def set_timestamp(self, path, access_nanoseconds=None, modify_nanoseconds=None, change_nanoseconds=None, relative_to=None):
+	def set_timestamp(self, path, access_ns=None, modify_ns=None, change_ns=None, relative_to=None):
 		"""Set timestamps for specified path
 
 		On Linux/Unix operating system we can't set metadata change timestamp
@@ -214,7 +214,7 @@ class LocalProvider(Provider):
 
 		"""
 		real_path = self.real_path(path, relative_to)
-		os.utime(real_path, ns=(access_nanoseconds, modify_nanoseconds))
+		os.utime(real_path, ns=(access_ns, modify_ns))
 
 	def move_path(self, source, destination, relative_to=None):
 		"""Move path on same file system to a different parent node """

--- a/sunflower/plugins/file_list/local_provider.py
+++ b/sunflower/plugins/file_list/local_provider.py
@@ -136,9 +136,9 @@ class LocalProvider(Provider):
 							time_access = 0,
 							time_modify = 0,
 							time_change = 0,
-							time_access_ns = 0,
-							time_modify_ns = 0,
-							time_change_ns = 0,
+							time_access_nanoseconds = 0,
+							time_modify_nanoseconds = 0,
+							time_change_nanoseconds = 0,
 							type = FileType.INVALID,
 							device = 0,
 							inode = 0
@@ -186,9 +186,9 @@ class LocalProvider(Provider):
 						time_access = file_stat.st_atime,
 						time_modify = file_stat.st_mtime,
 						time_change = file_stat.st_ctime,
-						time_access_ns = file_stat.st_atime_ns,
-						time_modify_ns = file_stat.st_mtime_ns,
-						time_change_ns = file_stat.st_ctime_ns,
+						time_access_nanoseconds = file_stat.st_atime_ns,
+						time_modify_nanoseconds = file_stat.st_mtime_ns,
+						time_change_nanoseconds = file_stat.st_ctime_ns,
 						type = item_type,
 						device = file_stat.st_dev,
 						inode = file_stat.st_ino
@@ -206,7 +206,7 @@ class LocalProvider(Provider):
 		real_path = self.real_path(path, relative_to)
 		os.chown(real_path, owner, group)
 
-	def set_timestamp(self, path, access_ns=None, modify_ns=None, change_ns=None, relative_to=None):
+	def set_timestamp(self, path, access_nanoseconds=None, modify_nanoseconds=None, change_nanoseconds=None, relative_to=None):
 		"""Set timestamps for specified path
 
 		On Linux/Unix operating system we can't set metadata change timestamp
@@ -214,7 +214,7 @@ class LocalProvider(Provider):
 
 		"""
 		real_path = self.real_path(path, relative_to)
-		os.utime(real_path, ns=(access_ns, modify_ns))
+		os.utime(real_path, ns=(access_nanoseconds, modify_nanoseconds))
 
 	def move_path(self, source, destination, relative_to=None):
 		"""Move path on same file system to a different parent node """

--- a/sunflower/plugins/file_list/local_provider.py
+++ b/sunflower/plugins/file_list/local_provider.py
@@ -136,6 +136,9 @@ class LocalProvider(Provider):
 							time_access = 0,
 							time_modify = 0,
 							time_change = 0,
+							time_access_ns = 0,
+							time_modify_ns = 0,
+							time_change_ns = 0,
 							type = FileType.INVALID,
 							device = 0,
 							inode = 0
@@ -183,6 +186,9 @@ class LocalProvider(Provider):
 						time_access = file_stat.st_atime,
 						time_modify = file_stat.st_mtime,
 						time_change = file_stat.st_ctime,
+						time_access_ns = file_stat.st_atime_ns,
+						time_modify_ns = file_stat.st_mtime_ns,
+						time_change_ns = file_stat.st_ctime_ns,
 						type = item_type,
 						device = file_stat.st_dev,
 						inode = file_stat.st_ino
@@ -200,7 +206,7 @@ class LocalProvider(Provider):
 		real_path = self.real_path(path, relative_to)
 		os.chown(real_path, owner, group)
 
-	def set_timestamp(self, path, access=None, modify=None, change=None, relative_to=None):
+	def set_timestamp(self, path, access_ns=None, modify_ns=None, change_ns=None, relative_to=None):
 		"""Set timestamps for specified path
 
 		On Linux/Unix operating system we can't set metadata change timestamp
@@ -208,7 +214,7 @@ class LocalProvider(Provider):
 
 		"""
 		real_path = self.real_path(path, relative_to)
-		os.utime(real_path, (access, modify))
+		os.utime(real_path, ns=(access_ns, modify_ns))
 
 	def move_path(self, source, destination, relative_to=None):
 		"""Move path on same file system to a different parent node """


### PR DESCRIPTION
This PR use `(st_atime_ns, st_mtime_ns)` instead of `(st_atime, st_mtime)` in `os.utime` to set timestamp exactly.

Below is a sample code to show the difference (pay attention to every atime_ns and mtime_ns):
```python3
import os
import time

fmt='atime: {}, atime_ns: {}, mtime: {}, mtime_ns: {}'

with open('a',mode='wb'):pass
a_stat=os.stat('a')
print('timestamp of a')
print(fmt.format(a_stat.st_atime,a_stat.st_atime_ns,a_stat.st_mtime,a_stat.st_mtime_ns))

time.sleep(1)

with open('b',mode='wb'):pass

print('timestamp of b, set with st_atime/st_mtime')
os.utime('b',times=(a_stat.st_atime,a_stat.st_mtime))
b_stat=os.stat('b')
print(fmt.format(b_stat.st_atime,b_stat.st_atime_ns,b_stat.st_mtime,b_stat.st_mtime_ns))

print('timestamp of b, set with st_atime_ns/st_mtime_ns')
os.utime('b',ns=(a_stat.st_atime_ns,a_stat.st_mtime_ns))
b_stat=os.stat('b')
print(fmt.format(b_stat.st_atime,b_stat.st_atime_ns,b_stat.st_mtime,b_stat.st_mtime_ns))
```