### PR TITLE
Toolbar fixes

### DIFF
--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -1976,6 +1976,7 @@ class MainWindow(Gtk.ApplicationWindow):
 		self.toolbar_options.update({
 					'style': 3,
 					'icon_size': 1,
+					'items': [],
 				})
 
 	def restore_handle_position(self, widget=None, data=None):

--- a/sunflower/gui/preferences/toolbar.py
+++ b/sunflower/gui/preferences/toolbar.py
@@ -110,10 +110,8 @@ class ToolbarOptions(SettingsPage):
 		# toolbar icon size
 		label_icon_size = Gtk.Label(label=_('Icon size:'))
 		list_icon_size = Gtk.ListStore(str, int)
-		list_icon_size.append((_('Same as menu item'), Gtk.IconSize.MENU))
 		list_icon_size.append((_('Small toolbar icon'), Gtk.IconSize.SMALL_TOOLBAR))
 		list_icon_size.append((_('Large toolbar icon'), Gtk.IconSize.LARGE_TOOLBAR))
-		list_icon_size.append((_('Same as buttons'), Gtk.IconSize.BUTTON))
 		list_icon_size.append((_('Same as drag icons'), Gtk.IconSize.DND))
 		list_icon_size.append((_('Same as dialog'), Gtk.IconSize.DIALOG))
 

--- a/sunflower/gui/preferences/toolbar.py
+++ b/sunflower/gui/preferences/toolbar.py
@@ -223,22 +223,12 @@ class ToolbarOptions(SettingsPage):
 
 		self._store.append((name, description, widget_type, icon, json.dumps(widget_config)))
 
-	def _set_selected_combobox_value(self, combobox, selected_value):
-		# find selected item by stored value (not item index)
-		active_index = 0
-		model = combobox.get_model()
-		for i, value in enumerate(model):
-			if value[1] == selected_value:
-				active_index = i
-				break
-		combobox.set_active(active_index)
-
 	def _load_options(self):
 		"""Load options from file"""
 		options = self._application.toolbar_options
 
-		self._set_selected_combobox_value(self._combobox_styles, options.get('style'))
-		self._set_selected_combobox_value(self._combobox_icon_size, options.get('icon_size'))
+		self._combobox_styles.set_active(options.get('style'))
+		self._combobox_icon_size.set_active(options.get('icon_size'))
 
 		# clear list store
 		self._store.clear()
@@ -246,18 +236,12 @@ class ToolbarOptions(SettingsPage):
 		for item in options.get('items'):
 			self._add_item_to_list(item)
 
-	def _get_active_combobox_value(self, combobox):
-		"""Get value from selected combobox item model"""
-		iter_ = combobox.get_active_iter()
-		model = combobox.get_model()
-		return model[iter_][1]
-
 	def _save_options(self):
 		"""Save settings to config file"""
 		options = self._application.toolbar_options
 
-		options.set('style', self._get_active_combobox_value(self._combobox_styles))
-		options.set('icon_size', self._get_active_combobox_value(self._combobox_icon_size))
+		options.set('style', self._combobox_styles.get_active())
+		options.set('icon_size', self._combobox_icon_size.get_active())
 
 		# save toolbar items settings
 		items = []

--- a/sunflower/gui/preferences/toolbar.py
+++ b/sunflower/gui/preferences/toolbar.py
@@ -248,9 +248,9 @@ class ToolbarOptions(SettingsPage):
 
 	def _get_active_combobox_value(self, combobox):
 		"""Get value from selected combobox item model"""
-		iter = combobox.get_active_iter()
+		iter_ = combobox.get_active_iter()
 		model = combobox.get_model()
-		return model[iter][1]
+		return model[iter_][1]
 
 	def _save_options(self):
 		"""Save settings to config file"""

--- a/sunflower/gui/preferences/toolbar.py
+++ b/sunflower/gui/preferences/toolbar.py
@@ -225,12 +225,22 @@ class ToolbarOptions(SettingsPage):
 
 		self._store.append((name, description, widget_type, icon, json.dumps(widget_config)))
 
+	def _set_selected_combobox_value(self, combobox, selected_value):
+		# find selected item by stored value (not item index)
+		active_index = 0
+		model = combobox.get_model()
+		for i, value in enumerate(model):
+			if value[1] == selected_value:
+				active_index = i
+				break
+		combobox.set_active(active_index)
+
 	def _load_options(self):
 		"""Load options from file"""
 		options = self._application.toolbar_options
 
-		self._combobox_styles.set_active(options.get('style'))
-		self._combobox_icon_size.set_active(options.get('icon_size'))
+		self._set_selected_combobox_value(self._combobox_styles, options.get('style'))
+		self._set_selected_combobox_value(self._combobox_icon_size, options.get('icon_size'))
 
 		# clear list store
 		self._store.clear()
@@ -238,14 +248,20 @@ class ToolbarOptions(SettingsPage):
 		for item in options.get('items'):
 			self._add_item_to_list(item)
 
+	def _get_active_combobox_value(self, combobox):
+		"""Get value from selected combobox item model"""
+		iter = combobox.get_active_iter()
+		model = combobox.get_model()
+		return model[iter][1]
+
 	def _save_options(self):
 		"""Save settings to config file"""
 		options = self._application.toolbar_options
 
-		options.set('style', self._combobox_styles.get_active())
-		options.set('icon_size', self._combobox_icon_size.get_active())
+		options.set('style', self._get_active_combobox_value(self._combobox_styles))
+		options.set('icon_size', self._get_active_combobox_value(self._combobox_icon_size))
 
-		# get list from configuration window
+		# save toolbar items settings
 		items = []
 		for data in self._store:
 			items.append({

--- a/sunflower/toolbar.py
+++ b/sunflower/toolbar.py
@@ -175,5 +175,18 @@ class ToolbarManager:
 
 	def apply_settings(self):
 		"""Apply toolbar settings"""
-		self._toolbar.set_style(self._config.get('style'))
-		self._toolbar.set_icon_size(self._config.get('icon_size'))
+		style = (
+			Gtk.ToolbarStyle.ICONS,
+			Gtk.ToolbarStyle.TEXT,
+			Gtk.ToolbarStyle.BOTH,
+			Gtk.ToolbarStyle.BOTH_HORIZ,
+		)[self._config.get('style')]
+		self._toolbar.set_style(style)
+
+		icon_size = (
+			Gtk.IconSize.SMALL_TOOLBAR,
+			Gtk.IconSize.LARGE_TOOLBAR,
+			Gtk.IconSize.DND,
+			Gtk.IconSize.DIALOG,
+		)[self._config.get('icon_size')]
+		self._toolbar.set_icon_size(icon_size)

--- a/sunflower/toolbar.py
+++ b/sunflower/toolbar.py
@@ -175,15 +175,5 @@ class ToolbarManager:
 
 	def apply_settings(self):
 		"""Apply toolbar settings"""
-		self._toolbar.set_style(self._config.get('style')) # fortunately style enums are equal to internal indexes
-		# but icon sizes are not, 0 index is invalid icon, so we need a lookup table
-		icon_sizes = [
-			Gtk.IconSize.MENU,
-			Gtk.IconSize.SMALL_TOOLBAR,
-			Gtk.IconSize.LARGE_TOOLBAR,
-			Gtk.IconSize.BUTTON,
-			Gtk.IconSize.DND,
-			Gtk.IconSize.DIALOG
-		]
-
-		self._toolbar.set_icon_size(icon_sizes[self._config.get('icon_size')])
+		self._toolbar.set_style(self._config.get('style'))
+		self._toolbar.set_icon_size(self._config.get('icon_size'))


### PR DESCRIPTION
Moved toolbar items to array to solve ordering issue #352 , removed two redundant icon sizes #395 . Added feature to rename toolbar buttons from list. Fixed formatting where spaces were used.

I don't like my current workaround for toolbar plugin extra data (storing json in listview), and applying active toolbar styles that requires to keep duplicate options array (similar implementation is used in item_list options). Would be great to hear suggestions how to implement them better.

At least now toolbar base is working and we can add a few more button plugins to make it perfect.