### PR TITLE
Toolbar fix bookmark button edit warning

### DIFF
--- a/sunflower/plugin_base/toolbar_factory.py
+++ b/sunflower/plugin_base/toolbar_factory.py
@@ -35,7 +35,7 @@ class ToolbarFactory:
 		"""
 		pass
 
-	def configure_widget(self, name, widget_type, config):
+	def configure_widget(self, name, widget_type, config, transient_window=None):
 		"""Present blocking configuration dialog for specified widget type.
 
 		Returns new config if changes were made otherwise None

--- a/sunflower/plugins/default_toolbar/bookmark_button.py
+++ b/sunflower/plugins/default_toolbar/bookmark_button.py
@@ -51,7 +51,7 @@ class ConfigurationDialog(Gtk.Dialog):
 	"""Configuration dialog for bookmark button"""
 
 	def __init__(self, application, name, config=None):
-		GObject.GObject.__init__(self, parent=application)
+		Gtk.Dialog.__init__(self, parent=application)
 
 		self._application = application
 

--- a/sunflower/plugins/default_toolbar/bookmark_button.py
+++ b/sunflower/plugins/default_toolbar/bookmark_button.py
@@ -51,13 +51,17 @@ class ConfigurationDialog(Gtk.Dialog):
 	"""Configuration dialog for bookmark button"""
 
 	def __init__(self, application, name, config=None):
-		Gtk.Dialog.__init__(self, parent=application)
+		Gtk.Dialog.__init__(
+			self,
+			parent=application,
+			use_header_bar=True,
+		)
 
 		self._application = application
 
 		# configure dialog
 		self.set_title(_('Configure bookmark button'))
-		self.set_default_size(340, 10)
+		self.set_default_size(450, 10)
 		self.set_resizable(True)
 		self.set_skip_taskbar_hint(True)
 		self.set_modal(True)
@@ -70,16 +74,6 @@ class ConfigurationDialog(Gtk.Dialog):
 		vbox.set_border_width(5)
 
 		# create interface
-		vbox_name = Gtk.VBox(False, 0)
-
-		label_name = Gtk.Label(label=_('Name:'))
-		label_name.set_alignment(0, 0.5)
-
-		entry_name = Gtk.Entry()
-		entry_name.set_editable(False)
-		entry_name.set_sensitive(False)
-		entry_name.set_text(name)
-
 		vbox_path = Gtk.VBox(False, 0)
 
 		label_path = Gtk.Label(label=_('Path:'))
@@ -104,13 +98,9 @@ class ConfigurationDialog(Gtk.Dialog):
 		self.set_default_response(Gtk.ResponseType.ACCEPT)
 
 		# pack interface
-		vbox_name.pack_start(label_name, False, False, 0)
-		vbox_name.pack_start(entry_name, False, False, 0)
-
 		vbox_path.pack_start(label_path, False, False, 0)
 		vbox_path.pack_start(self._entry_path, False, False, 0)
 
-		vbox.pack_start(vbox_name, False, False, 0)
 		vbox.pack_start(vbox_path, False, False, 0)
 		vbox.pack_start(self._checkbox_show_label, False, False, 0)
 

--- a/sunflower/plugins/default_toolbar/plugin.py
+++ b/sunflower/plugins/default_toolbar/plugin.py
@@ -71,7 +71,7 @@ class DefaultToolbar(ToolbarFactory):
 
 		if DialogClass is not None:
 			# create configuration dialog
-			dialog = DialogClass(self._application, name)
+			dialog = DialogClass(transient_window, name)
 
 			# set transistent window
 			if transient_window is not None:
@@ -82,14 +82,14 @@ class DefaultToolbar(ToolbarFactory):
 
 		return config
 
-	def configure_widget(self, name, widget_type, config):
+	def configure_widget(self, name, widget_type, config, transient_window=None):
 		"""Configure specified widget"""
 		result = None
 		DialogClass = self._widgets[widget_type]['dialog']
 
 		if DialogClass is not None:
 			# create configuration dialog
-			dialog = DialogClass(self._application, name, config)
+			dialog = DialogClass(transient_window, name, config)
 
 			# show dialog and get use input
 			result = dialog.get_response()
@@ -97,7 +97,7 @@ class DefaultToolbar(ToolbarFactory):
 		else:
 			# there is no configuration dialog for this widget type
 			dialog = Gtk.MessageDialog(
-		                            self._application,
+		                            transient_window,
 		                            Gtk.DialogFlags.DESTROY_WITH_PARENT,
 		                            Gtk.MessageType.INFO,
 		                            Gtk.ButtonsType.OK,

--- a/sunflower/toolbar.py
+++ b/sunflower/toolbar.py
@@ -114,7 +114,7 @@ class ToolbarManager:
 			if None in (name, widget_type) or name == '':
 				# user didn't input all the data
 				dialog = Gtk.MessageDialog(
-					self._application,
+					window,
 					Gtk.DialogFlags.DESTROY_WITH_PARENT,
 					Gtk.MessageType.ERROR,
 					Gtk.ButtonsType.OK,
@@ -148,7 +148,7 @@ class ToolbarManager:
 		if not widget_type in self._factory_cache:
 			# there is no factory for specified type, show error and return
 			dialog = Gtk.MessageDialog(
-				self._application,
+				window,
 				Gtk.DialogFlags.DESTROY_WITH_PARENT,
 				Gtk.MessageType.ERROR,
 				Gtk.ButtonsType.OK,
@@ -167,7 +167,7 @@ class ToolbarManager:
 		factory = self._factory_cache[widget_type]
 
 		# load config
-		config = factory.configure_widget(name, widget_type, widget_config)
+		config = factory.configure_widget(name, widget_type, widget_config, window)
 		if config:
 			return config
 


### PR DESCRIPTION
Fixed parent window references for modal dialogs in Toolbar preferences. Updated "Bookmark Button" edit dialog style to use header bar and removed name editing field, as it was not very useful in disabled state.
Fixes #398 