### PR TITLE
Terminal: fix argument passed to feed_child function

### DIFF
--- a/sunflower/plugin_base/terminal.py
+++ b/sunflower/plugin_base/terminal.py
@@ -333,7 +333,7 @@ class Terminal(PluginBase):
 
 	def feed_terminal(self, text):
 		"""Feed terminal process with specified text"""
-		self._terminal.feed_child(text)
+		self._terminal.feed_child(text.encode())
 
 	def apply_settings(self):
 		"""Apply terminal settings"""


### PR DESCRIPTION
While triaging issue #234 found a bit different issue and fixed it. This probably closes #234 too, as functionality mentioned in issue is working correctly.