### PR TITLE
Item list: improve inherit path functionality

### DIFF
--- a/sunflower/plugin_base/item_list.py
+++ b/sunflower/plugin_base/item_list.py
@@ -1406,13 +1406,18 @@ class ItemList(PluginBase):
 	def _inherit_left_path(self, widget, data=None):
 		"""Inherit path in right list from left"""
 		opposite_object = self._parent.get_opposite_object(self)
+		selection = self._get_selection()
+		if ((selection is not None) and (self.get_provider().is_dir(selection))):
+			selected_path = selection
+		else:
+			selected_path = self.path
 
 		if self._notebook is self._parent.left_notebook:
 			if hasattr(opposite_object, 'change_path'):
-				opposite_object.change_path(self.path)
+				opposite_object.change_path(selected_path)
 
 			elif hasattr(opposite_object, 'feed_terminal'):
-				opposite_object.feed_terminal(self.path)
+				opposite_object.feed_terminal(selected_path)
 
 		else:
 			self.change_path(opposite_object.path)
@@ -1422,13 +1427,18 @@ class ItemList(PluginBase):
 	def _inherit_right_path(self, widget, data=None):
 		"""Inherit path in left list from right"""
 		opposite_object = self._parent.get_opposite_object(self)
+		selection = self._get_selection()
+		if ((selection is not None) and (self.get_provider().is_dir(selection))):
+			selected_path = selection
+		else:
+			selected_path = self.path
 
 		if self._notebook is self._parent.right_notebook:
 			if hasattr(opposite_object, 'change_path'):
-				opposite_object.change_path(self.path)
+				opposite_object.change_path(selected_path)
 
 			elif hasattr(opposite_object, 'feed_terminal'):
-				opposite_object.feed_terminal(self.path)
+				opposite_object.feed_terminal(selected_path)
 
 		else:
 			self.change_path(opposite_object.path)

--- a/sunflower/plugin_base/item_list.py
+++ b/sunflower/plugin_base/item_list.py
@@ -1407,7 +1407,7 @@ class ItemList(PluginBase):
 		"""Inherit path in right list from left"""
 		opposite_object = self._parent.get_opposite_object(self)
 		selection = self._get_selection()
-		if ((selection is not None) and (self.get_provider().is_dir(selection))):
+		if selection and self.get_provider().is_dir(selection):
 			selected_path = selection
 		else:
 			selected_path = self.path
@@ -1428,7 +1428,7 @@ class ItemList(PluginBase):
 		"""Inherit path in left list from right"""
 		opposite_object = self._parent.get_opposite_object(self)
 		selection = self._get_selection()
-		if ((selection is not None) and (self.get_provider().is_dir(selection))):
+		if selection and self.get_provider().is_dir(selection):
 			selected_path = selection
 		else:
 			selected_path = self.path


### PR DESCRIPTION
As requested in #127 when selection is over directory, highlighted directory is opened in opposite panel. When selected file or parent directory item - current path is opened. Works with terminal too.
Fixes #127 

Nice improvement might be to use single function for _inherit_left_path() and _inherit_right_path(), but I currently have no idea how to implement that correctly.
