### PR TITLE
File list: fix issue with incorrectly set providers

### DIFF
--- a/sunflower/plugin_base/item_list.py
+++ b/sunflower/plugin_base/item_list.py
@@ -1660,8 +1660,7 @@ class ItemList(PluginBase):
 			result = self.create_provider(path, False)
 
 		# cache current provider
-		if self._current_provider is None:
-			self._current_provider = result
+		self._current_provider = result
 
 		return result
 

--- a/sunflower/plugins/file_list/file_list.py
+++ b/sunflower/plugins/file_list/file_list.py
@@ -1383,7 +1383,7 @@ class FileList(ItemList):
 				parent = self._find_iter_by_name(fragment, parent)
 
 		# check for list of always hidden files
-		provider = self.get_provider(parent_path)
+		provider = self.get_provider()
 		always_hidden = []
 
 		if not show_hidden and provider.exists('.hidden', relative_to=parent_path):


### PR DESCRIPTION
My last attempt to fix trash list https://github.com/MeanEYE/Sunflower/commit/e18476119a985042138d3b05acbfaec6a7ece96d resulted in broken archive support.
This commit with upcoming one, that fixes bug in breadcrumbs, should result in correctly working zip archive provider and trash list.
get_provider() function checking hidden files used incorrect path and that resulted in provider being switched to localProvider.