### PR TITLE
Breadcrumbs: fix unnecessary path change

### DIFF
--- a/sunflower/widgets/breadcrumbs.py
+++ b/sunflower/widgets/breadcrumbs.py
@@ -34,6 +34,10 @@ class Breadcrumbs:
 		if self._updating:
 			return
 
+		# ignore non active buttons
+		if not widget.props.active:
+			return
+
 		# change path
 		file_list = self._parent._parent
 		if hasattr(file_list, 'change_path'):


### PR DESCRIPTION
After opening zip archive, breadcrumbs button with current path is activated. That causes first button to get clicked event first and do a path change to parent directory. Combined with provider change that resulted in empty archive listing. Opening zip archive second time works correctly, because breadcrumbs bar is already set to correct location.

When testing current version after opening zip archive one will notice that it has incorrect "folder" icon set and error in terminal complaining about not being able to open directory.  