### PR TITLE
set time_*_ns in any FileInfoExtended

### DIFF
--- a/sunflower/plugins/archive_support/zip_provider.py
+++ b/sunflower/plugins/archive_support/zip_provider.py
@@ -173,6 +173,9 @@ class ZipProvider(Provider):
 							time_access = 0,
 							time_modify = result.time_modify,
 							time_change = 0,
+							time_access_ns = 0,
+							time_modify_ns = result.time_modify * 10**9,
+							time_change_ns = 0,
 							type = result.type,
 							device = 0,
 							inode = 0
@@ -200,6 +203,9 @@ class ZipProvider(Provider):
 							time_access = 0,
 							time_modify = 0,
 							time_change = 0,
+							time_access_ns = 0,
+							time_modify_ns = 0,
+							time_change_ns = 0,
 							type = FileType.INVALID,
 							device = 0,
 							inode = 0

--- a/sunflower/plugins/file_list/gio_provider.py
+++ b/sunflower/plugins/file_list/gio_provider.py
@@ -157,6 +157,9 @@ class GioProvider(Provider):
 							time_access = 0,
 							time_modify = 0,
 							time_change = 0,
+							time_access_ns = 0,
+							time_modify_ns = 0,
+							time_change_ns = 0,
 							type = FileType.INVALID,
 							device = 0,
 							inode = 0
@@ -200,6 +203,9 @@ class GioProvider(Provider):
 						time_access = file_stat.get_attribute_uint64(Gio.FILE_ATTRIBUTE_TIME_ACCESS),
 						time_modify = file_stat.get_attribute_uint64(Gio.FILE_ATTRIBUTE_TIME_MODIFIED),
 						time_change = file_stat.get_attribute_uint64(Gio.FILE_ATTRIBUTE_TIME_CHANGED),
+						time_access_ns = file_stat.get_attribute_uint64(Gio.FILE_ATTRIBUTE_TIME_ACCESS) * 10**9,
+						time_modify_ns = file_stat.get_attribute_uint64(Gio.FILE_ATTRIBUTE_TIME_MODIFIED) * 10**9,
+						time_change_ns = file_stat.get_attribute_uint64(Gio.FILE_ATTRIBUTE_TIME_CHANGED) * 10**9,
 						type = item_type,
 						device = file_stat.get_attribute_uint32(Gio.FILE_ATTRIBUTE_UNIX_DEVICE),
 						inode = file_stat.get_attribute_uint64(Gio.FILE_ATTRIBUTE_UNIX_INODE)


### PR DESCRIPTION
This PR try to fix #408.

I could not exactly point where the exception raised, but any `FileInfoExtended` should inited with *_ns attribute.