### PR TITLE
Archive support: return correct root path

### DIFF
--- a/sunflower/plugins/archive_support/zip_provider.py
+++ b/sunflower/plugins/archive_support/zip_provider.py
@@ -250,7 +250,7 @@ class ZipProvider(Provider):
 
 	def get_root_path(self, path):
 		"""Get root for specified path"""
-		return os.path.dirname(self._path)
+		return 'file:///' if path.startswith('file://') else os.path.sep
 
 	def get_parent_path(self, path):
 		"""Get parent path for specified"""


### PR DESCRIPTION
Simple workaround for breadcrumbs issue when opening zip archive. Just copied functionality from local_provider.py When different mount display (remote drives, optical drives, etc.) will be implemented in breadcrumbs, this will need adjusting. Until then having this fix will help to find other existing issues with breadcrumbs and zip provider.
Fixes #332 