### PR TITLE
Main window: pass self reference to edit dialog

### DIFF
--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -957,7 +957,7 @@ class MainWindow(Gtk.ApplicationWindow):
 		active_object = self.get_active_object()
 
 		if hasattr(active_object, '_edit_selected'):
-			active_object._edit_selected()
+			active_object._edit_selected(self)
 			result = True
 
 		return result


### PR DESCRIPTION
Move cursor over directory or parent directory indicator in file list. Press "Edit" button in command bar. Error modal dialog is opened without parent, so it doesn't dim main window correctly.
Added parent param to fix that issue.