### PR TITLE
MountsManager: check volume is mounted before mount

### DIFF
--- a/sunflower/mounts.py
+++ b/sunflower/mounts.py
@@ -24,7 +24,7 @@ class MountsManager:
 		automount = self._application.options.section('operations').get('automount_start')
 		for volume in self._volume_monitor.get_volumes():
 			self._location_menu.add_location(Volume(self, volume))
-			if automount and volume.can_mount():
+			if automount and volume.can_mount() and volume.get_mount() is None:
 				volume.mount(Gio.MountMountFlags.NONE, None, None, self._handle_mount_finish, None)
 
 	def _handle_add_volume(self, monitor, volume):
@@ -32,7 +32,8 @@ class MountsManager:
 		self._location_menu.add_location(Volume(self, volume))
 
 		# automount volume if needed
-		if self._application.options.section('operations').get('automount_insert') and volume.can_mount():
+		automount_insert = self._application.options.section('operations').get('automount_insert')
+		if automount_insert and volume.can_mount() and volume.get_mount() is None:
 			volume.mount(Gio.MountMountFlags.NONE, None, None, self._handle_mount_finish, None)
 
 	def _handle_remove_volume(self, widget, volume):
@@ -53,7 +54,7 @@ class MountsManager:
 
 	def mount(self, volume):
 		"""Perform volume mount."""
-		if volume.can_mount():
+		if volume.can_mount() and volume.get_mount() is None:
 			volume.mount(Gio.MountMountFlags.NONE, None, None, self._handle_mount_finish, None)
 
 		else:


### PR DESCRIPTION
Sunflower attempt to mount volumes even volume already mounted which entails the errors

```
Traceback (most recent call last):
  File "/home/arseniy/Sunflower/sunflower/mounts.py", line 45, in _handle_mount_finish
    mount.mount_finish(result)
gi.repository.GLib.Error: g-io-error-quark: mount: /: must be superuser to use mount.
 (0)
Traceback (most recent call last):
  File "/home/arseniy/Sunflower/sunflower/mounts.py", line 45, in _handle_mount_finish
    mount.mount_finish(result)
gi.repository.GLib.Error: g-io-error-quark: mount: /boot: must be superuser to use mount.
 (0)
```

To avoid this we should check is volume already mounted https://developer.gnome.org/pygobject/stable/class-giovolume.html#method-giovolume--get-mount