### PR TITLE
Setup.py fixes

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 from setuptools import setup, find_packages
+from pathlib import Path
 
 def get_version():
 	"""Get software version from the main window."""
@@ -26,9 +27,10 @@ setup(
 		packages=find_packages(),
 		include_package_data=True,
 		data_files=[
-			('images', ['images/sunflower.svg']),
-			('images', ['images/splash.png']),
+			('share/sunflower/images/', list(str(i) for i in Path('images/').rglob('*') if i.is_file())),
+			('share/sunflower/trasnaltions', list(str(i) for i in Path('translations/').rglob('*') if i.is_file())),
+			('share/sunflower/styles', ['sunflower/styles/main.css']),
 			('share/applications', ['Sunflower.desktop'])
-			],
+		],
 		entry_points={'console_scripts': ['sunflower = sunflower.__main__:main']}
-		)
+)

--- a/sunflower/common.py
+++ b/sunflower/common.py
@@ -83,6 +83,16 @@ def get_base_directory():
 	"""Return base directory where application is installed."""
 	return os.path.dirname(__file__)
 
+def get_static_assets_directory():
+	"""Return path to directory that holds static files"""
+	script_dir = os.path.dirname(__file__)
+	prefix_dir = os.path.join(sys.prefix, 'share', 'sunflower')
+
+	if os.path.exists(os.path.join(script_dir, 'images', 'sunflower.svg')):
+		return script_dir
+	else:
+		return prefix_dir
+
 def get_cache_directory():
 	"""Get full path to cache files for curring user."""
 	if 'XDG_CACHE_HOME' in os.environ:
@@ -172,7 +182,7 @@ def executable_exists(command):
 def load_translation():
 	"""Load translation and install global functions"""
 	# get directory for translations
-	base_path = os.path.dirname(get_base_directory())
+	base_path = os.path.dirname(get_static_assets_directory())
 	directory = os.path.join(base_path, 'translations')
 
 	# function params

--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -914,7 +914,7 @@ class MainWindow(Gtk.ApplicationWindow):
 		screen = Gdk.Screen.get_default()
 
 		# prepare path to load from
-		file_name = os.path.join(common.get_base_directory(), 'styles', 'main.css')
+		file_name = os.path.join(common.get_static_assets_directory(), 'styles', 'main.css')
 
 		# try loading from zip file
 		if os.path.isfile(sys.path[0]) and sys.path[0] != '':

--- a/sunflower/icons.py
+++ b/sunflower/icons.py
@@ -6,7 +6,7 @@ import sys
 import zipfile
 
 from gi.repository import Gtk, Gio, GdkPixbuf, GLib
-from sunflower.common import UserDirectory, get_user_directory, get_base_directory
+from sunflower.common import UserDirectory, get_user_directory, get_static_assets_directory
 
 
 class IconManager:
@@ -132,6 +132,6 @@ class IconManager:
 
 		# load from local path
 		else:
-			base_path = os.path.dirname(get_base_directory())
+			base_path = get_static_assets_directory()
 			window.set_icon_from_file(os.path.join(base_path, 'images', 'sunflower.svg'))
 

--- a/sunflower/indicator.py
+++ b/sunflower/indicator.py
@@ -13,7 +13,7 @@ class Indicator(object):
 		self._menu = Gtk.Menu()
 		self._create_menu_items()
 
-		base_path = os.path.dirname(common.get_base_directory())
+		base_path = os.path.dirname(common.get_static_assets_directory())
 
 		self._icon = 'sunflower_64.png'
 		self._icon_path = os.path.abspath(os.path.join(base_path, 'images'))

--- a/sunflower/notifications.py
+++ b/sunflower/notifications.py
@@ -36,7 +36,7 @@ class NotificationManager:
 
 		else:
 			# use local icon
-			icon_file = os.path.join(os.path.dirname(common.get_base_directory()), 'images', 'sunflower_64.png')
+			icon_file = os.path.join(os.path.dirname(common.get_static_assets_directory()), 'images', 'sunflower_64.png')
 			self._default_icon = 'file://{0}'.format(icon_file)
 
 	def notify(self, title, text, icon=None):


### PR DESCRIPTION
Please consider those changes to make Sunflower working when installed as legit Python package, After merge I'd appreciate if you could do (beta) release of it, so we can finally drop Python2-only Sunflower from Gentoo.

Ideally you could switch to python-stdeb to build legit .deb with sunflower, while passing some additional options to add non-python dependencies there. That would allow to simplify code and always rely on sys.prefix.