### PR TITLE
Replace long with int

### DIFF
--- a/sunflower/gui/keyring_manager_window.py
+++ b/sunflower/gui/keyring_manager_window.py
@@ -43,7 +43,7 @@ class KeyringManagerWindow:
 		container.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 		container.set_shadow_type(Gtk.ShadowType.IN)
 
-		self._store = Gtk.ListStore(long, str, str)
+		self._store = Gtk.ListStore(int, str, str)
 		self._list = Gtk.TreeView(model=self._store)
 
 		cell_id = Gtk.CellRendererText()

--- a/sunflower/plugins/file_list/gio_provider.py
+++ b/sunflower/plugins/file_list/gio_provider.py
@@ -246,21 +246,21 @@ class GioProvider(Provider):
 			temp.set_attribute(
 					Gio.FILE_ATTRIBUTE_TIME_ACCESS,
 					Gio.FILE_ATTRIBUTE_TYPE_UINT64,
-					long(access)
+					int(access)
 				)
 
 		if modify is not None:
 			temp.set_attribute(
 					Gio.FILE_ATTRIBUTE_TIME_MODIFIED,
 					Gio.FILE_ATTRIBUTE_TYPE_UINT64,
-					long(modify)
+					int(modify)
 				)
 
 		if change is not None:
 			temp.set_attribute(
 					Gio.FILE_ATTRIBUTE_TIME_CHANGED,
 					Gio.FILE_ATTRIBUTE_TYPE_UINT64,
-					long(change)
+					int(change)
 				)
 
 	def move_path(self, source, destination, relative_to=None):


### PR DESCRIPTION
The former was removed in Python 3, int is now unbounded.

This fixes error:

	Traceback (most recent call last):
	  File "/nix/store/0pgpnirdcai1ggv4a6xn6i9aw72zz2vx-sunflower-2020-07-03-unstable/lib/python3.8/site-packages/sunflower/gui/main_window.py", line 2507, in show_keyring_manager
	    KeyringManagerWindow(self)
	  File "/nix/store/0pgpnirdcai1ggv4a6xn6i9aw72zz2vx-sunflower-2020-07-03-unstable/lib/python3.8/site-packages/sunflower/gui/keyring_manager_window.py", line 46, in __init__
	    self._store = Gtk.ListStore(long, str, str)
	NameError: name 'long' is not defined
