### PR TITLE
Install plug-in .conf files

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 recursive-include sunflower *.css
+recursive-include sunflower *.conf

--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -1593,9 +1593,11 @@ class MainWindow(Gtk.ApplicationWindow):
 	def goto_web(self, widget, uri):
 		"""Open URL stored in data"""
 		if uri is None:
-			uri = 'sunflower-fm.org'
+			uri = 'https://sunflower-fm.org'
+		elif '://' not in uri:
+			uri = 'https://{}'.format(uri)
 
-		webbrowser.open_new_tab('https://{}'.format(uri))
+		webbrowser.open_new_tab(uri)
 		return True
 
 	def execute_command(self, widget, data=None):


### PR DESCRIPTION
setup.py does not install .conf files by default, leading to descriptions not being shown.
