### PR TITLE
Port to libsecret

### DIFF
--- a/sunflower/gui/keyring_manager_window.py
+++ b/sunflower/gui/keyring_manager_window.py
@@ -7,7 +7,7 @@ from sunflower.gui.input_dialog import PasswordDialog
 
 
 class Column:
-	ID = 0
+	OBJECT_PATH = 0
 	NAME = 1
 	MODIFIED = 2
 
@@ -43,14 +43,14 @@ class KeyringManagerWindow:
 		container.set_policy(Gtk.PolicyType.AUTOMATIC, Gtk.PolicyType.AUTOMATIC)
 		container.set_shadow_type(Gtk.ShadowType.IN)
 
-		self._store = Gtk.ListStore(int, str, str)
+		self._store = Gtk.ListStore(str, str, str)
 		self._list = Gtk.TreeView(model=self._store)
 
 		cell_id = Gtk.CellRendererText()
 		cell_name = Gtk.CellRendererText()
 		cell_modified = Gtk.CellRendererText()
 
-		col_id = Gtk.TreeViewColumn(_('ID'), cell_id, text=Column.ID)
+		col_id = Gtk.TreeViewColumn(_('Object path'), cell_id, text=Column.OBJECT_PATH)
 		col_name = Gtk.TreeViewColumn(_('Name'), cell_name, text=Column.NAME)
 		col_name.set_expand(True)
 		col_modified = Gtk.TreeViewColumn(_('Modified'), cell_modified, text=Column.MODIFIED)
@@ -100,9 +100,9 @@ class KeyringManagerWindow:
 		keyring_manager = self._application.keyring_manager
 		time_format = section.get('time_format')
 
-		for uid, name, modified in keyring_manager.get_entries():
+		for object_path, name, modified in keyring_manager.get_entries():
 			formatted_time = time.strftime(time_format, time.localtime(modified))
-			self._store.append((uid, name, formatted_time))
+			self._store.append((object_path, name, formatted_time))
 
 	def __delete_event(self, widget, data=None):
 		"""Cleanup on window delete event"""
@@ -185,7 +185,7 @@ class KeyringManagerWindow:
 		if response[0] == Gtk.ResponseType.OK:
 			if response[1] == response[2]:
 				# passwords match, change value
-				item_id = item_list.get_value(selected_iter, Column.ID)
+				item_id = item_list.get_value(selected_iter, Column.OBJECT_PATH)
 				self._application.keyring_manager.change_secret(item_id, response[1])
 
 				dialog = Gtk.MessageDialog(


### PR DESCRIPTION
libgnome-keyring library has been [deprecated] for a long time now, it has been replaced by libsecret library. libsecret uses Freedesktop.org’s Secret Service D-Bus API, which is supported by GNOME Keyring, so the old keyring (called collection in Secret Service parlance) should be still usable.

Major differences are:
* objects are now D-Bus objects and their properties can be watched for changes, most of them are also loaded automatically
* items are no longer identified by an unsigned integer, applications should retrieve items based on their attributes. It is also possible to identify an item by its DBus object path
* password prompt is now handled by the secret manager (e.g. GNOME Keyring)

Relevant documentation:

* [PyGobject docs]
* [Secret Service spec]
* [libgnome-keyring docs]
* [libsecret docs]
* [migration guide]

[PyGobject docs]: https://lazka.github.io/pgi-docs/index.html#Secret-1/classes/Service.html#Secret.Service
[Secret Service spec]: https://specifications.freedesktop.org/secret-service/latest/re01.html
[libgnome-keyring docs]: https://developer.gnome.org/gnome-keyring/stable/gnome-keyring-Simple-Password-Storage.html
[libsecret docs]: https://developer.gnome.org/libsecret/unstable/SecretCollection.html#secret-collection-for-alias
[deprecated]: https://wiki.gnome.org/Initiatives/GnomeGoals/LibsecretMigration
[migration guide]: https://developer.gnome.org/libsecret/unstable/migrating-api.html

It was not clear from the documentation whether the keyring name set by libgnome-keyring is the same as alias in libsecret, I will need to find out how to actually use this code so that I could check that.
Some items are also not loaded by default; we will need to double check that there are no code paths forgetting to load the necessary data. Lastly, we will need to decide what to do on failures and check that all re-raised exceptions are caught. Maybe we should also use the object paths instead of iterating on labels
