### PR TITLE
Icons: use correct icon name for Downloads folder

### DIFF
--- a/sunflower/icons.py
+++ b/sunflower/icons.py
@@ -37,7 +37,7 @@ class IconManager:
 		directories = []
 		icon_names = {
 				UserDirectory.DESKTOP: 'user-desktop',
-				UserDirectory.DOWNLOADS: 'folder-downloads',
+				UserDirectory.DOWNLOADS: 'folder-download',
 				UserDirectory.TEMPLATES: 'folder-templates',
 				UserDirectory.PUBLIC: 'folder-publicshare',
 				UserDirectory.DOCUMENTS: 'folder-documents',


### PR DESCRIPTION
Use correct icon name for Downloads folder, now files list and properties window will display correct icon, same as GNOME Files.