### PR TITLE
Item list: updated deprecated menu popup functions

### DIFF
--- a/sunflower/plugin_base/item_list.py
+++ b/sunflower/plugin_base/item_list.py
@@ -376,11 +376,15 @@ class ItemList(PluginBase):
 		"""Show quick emblem selection menu."""
 		if data is not None:
 			# if this method is called by accelerator data is actually keyval
-			self._emblem_menu.popup(None, None, self._get_popup_menu_position, None, 1, 0)
-
+			self._emblem_menu.popup_at_rect(self._parent.get_window(),
+				self._get_popup_menu_position(),
+				Gdk.Gravity.SOUTH_WEST,
+				Gdk.Gravity.NORTH_WEST,
+				None
+			)
 		else:
 			# if called by mouse, we don't have the need to position the menu manually
-			self._emblem_menu.popup(None, None, None, None, 1, 0)
+			self._emblem_menu.popup_at_pointer()
 
 		return True
 
@@ -918,7 +922,7 @@ class ItemList(PluginBase):
 
 	def _get_popup_menu_position(self, menu, *args):
 		"""Abstract method for positioning menu properly on given row"""
-		return 0, 0, True
+		return Gdk.Rectangle()
 
 	def _get_history_menu_position(self, menu, *args):
 		"""Get history menu position"""
@@ -1215,7 +1219,13 @@ class ItemList(PluginBase):
 		self._prepare_popup_menu()
 
 		# if this method is called by Menu key data is actually event object
-		self._open_with_menu.popup(None, None, self._get_popup_menu_position, None, 1, 0)
+		self._open_with_menu.popup_at_rect(self._parent.get_window(),
+			self._get_popup_menu_position(),
+			Gdk.Gravity.SOUTH_WEST,
+			Gdk.Gravity.NORTH_WEST,
+			None
+		)
+
 		return True
 
 	def _show_popup_menu(self, widget=None, data=None):
@@ -1225,11 +1235,16 @@ class ItemList(PluginBase):
 
 		if data is not None:
 			# if this method is called by accelerator data is actually keyval
-			self._popup_menu.popup(None, None, self._get_popup_menu_position, None, 1, 0)
+			self._popup_menu.popup_at_rect(self._parent.get_window(),
+				self._get_popup_menu_position(),
+				Gdk.Gravity.SOUTH_WEST,
+				Gdk.Gravity.NORTH_WEST,
+				None
+			)
 
 		else:
 			# if called by mouse, we don't have the need to position the menu manually
-			self._popup_menu.popup(None, None, None, None, 1, 0)
+			self._popup_menu.popup_at_pointer()
 
 		return True
 

--- a/sunflower/plugins/file_list/file_list.py
+++ b/sunflower/plugins/file_list/file_list.py
@@ -1250,11 +1250,8 @@ class FileList(ItemList):
 		rect = self._item_list.get_cell_area(item_list.get_path(selected_iter), self._columns[0])
 		tree_rect = self._item_list.get_visible_rect()
 
-		# grab window coordinates
-		window_x, window_y = self._parent.get_window().get_position()
-
 		# relative to tree
-		x, y = rect.x, rect.y + rect.height
+		x, y = rect.x, rect.y
 		x, y = self._item_list.convert_tree_to_widget_coords(x, y)
 
 		# modify coordinate by tree display rectangle vertical offset
@@ -1262,12 +1259,10 @@ class FileList(ItemList):
 
 		# relative to window
 		x, y = self._item_list.translate_coordinates(self._parent, x, y)
-
-		# relative to screen
-		x += window_x
-		y += window_y
-
-		return x, y, True
+		
+		# return calculated coordinates and original cell dimensions
+		rect.x, rect.y = x, y
+		return rect
 
 	def _set_sort_function(self, widget, data=None):
 		"""Set sorting method stored in data
@@ -1978,7 +1973,7 @@ class FileList(ItemList):
 		# show menu in separate user interface thread
 		menu.show_all()
 		menu.connect('deactivate', Gtk.main_quit)
-		menu.popup(None, None, None, None, 1, 0)
+		menu.popup_at_pointer()
 		Gtk.main()
 
 		return result[0] if result else None


### PR DESCRIPTION
Updated deprecated menu popup() functions in item_list and file_list. Fixes #434 . Popups in items list are correctly positioned and doesn't go outside of screen. Tested on Wayland, also tested with "Menu" keyboard key to make sure that menu popups does not cover selected item.

I've left single popup() function not updated, because I couldn't find a way to call that function, more info #462 .