### PR TITLE
Updated deprecated menu popup functions

### DIFF
--- a/sunflower/gui/preferences/associations.py
+++ b/sunflower/gui/preferences/associations.py
@@ -1,4 +1,4 @@
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 from sunflower.gui.input_dialog import InputDialog, ApplicationInputDialog
 from sunflower.widgets.settings_page import SettingsPage
 
@@ -68,7 +68,7 @@ class AssociationsOptions(SettingsPage):
 
 	def __button_add_clicked(self, widget, data=None):
 		"""Handle clicking on add button"""
-		self._add_menu.popup(None, None, self.__get_menu_position, widget, 1, 0)
+		self._add_menu.popup_at_widget(widget, Gdk.Gravity.SOUTH_WEST, Gdk.Gravity.NORTH_WEST, None)
 
 	def __add_mime_type(self, widget, data=None):
 		"""Show dialog for adding mime type"""
@@ -132,20 +132,6 @@ class AssociationsOptions(SettingsPage):
 								)
 			dialog.run()
 			dialog.destroy()
-
-	def __get_menu_position(self, menu, *args):
-		"""Get history menu position"""
-		# get coordinates
-		button = args[-1]
-		window_x, window_y = self._parent.get_window().get_position()
-		button_x, button_y = button.translate_coordinates(self._parent, 0, 0)
-		button_h = button.get_allocation().height
-
-		# calculate absolute menu position
-		pos_x = window_x + button_x
-		pos_y = window_y + button_y + button_h
-
-		return pos_x, pos_y, True
 
 	def _load_options(self):
 		"""Load options and update interface"""

--- a/sunflower/gui/preferences/item_list.py
+++ b/sunflower/gui/preferences/item_list.py
@@ -406,21 +406,7 @@ class ItemListOptions(SettingsPage):
 
 	def __button_add_clicked(self, widget, data=None):
 		"""Handle clicking on add button"""
-		self._menu_add_directory.popup(None, None, self.__get_menu_position, widget, 1, 0)
-
-	def __get_menu_position(self, menu, *args):
-		"""Get history menu position"""
-		# get coordinates
-		button = args[-1]
-		window_x, window_y = self._parent.get_window().get_position()
-		button_x, button_y = button.translate_coordinates(self._parent, 0, 0)
-		button_h = button.get_allocation().height
-
-		# calculate absolute menu position
-		pos_x = window_x + button_x
-		pos_y = window_y + button_y + button_h
-
-		return pos_x, pos_y, True
+		self._add_menu_directory.popup_at_widget(widget, Gdk.Gravity.SOUTH_WEST, Gdk.Gravity.NORTH_WEST, None)
 
 	def _add_always_visible(self, widget, data=None):
 		"""Add item name to the list of always visible files and directories."""

--- a/sunflower/plugin_base/terminal.py
+++ b/sunflower/plugin_base/terminal.py
@@ -193,27 +193,13 @@ class Terminal(PluginBase):
 		PluginBase._duplicate_tab(self, None, self._options)
 		return True
 
-	def _get_menu_position(self, menu, *args):
-		"""Get history menu position"""
-		# get coordinates
-		button = args[-1]
-		window_x, window_y = self._parent.get_position()
-		button_x, button_y = button.translate_coordinates(self._parent, 0, 0)
-		button_h = button.get_allocation().height
-
-		# calculate absolute menu position
-		pos_x = window_x + button_x
-		pos_y = window_y + button_y + button_h
-
-		return pos_x, pos_y, True
-
 	def _show_terminal_menu(self, widget, data=None):
 		"""History button click event"""
 		# prepare menu for drawing
 		self._prepare_menu()
 
-		# show the menu on calculated location
-		self._menu.popup(None, None, self._get_menu_position, widget, 1, 0)
+		# show the menu
+		self._menu.popup_at_widget(widget, Gdk.Gravity.SOUTH_WEST, Gdk.Gravity.NORTH_WEST, None)
 
 	def _configure_accelerators(self):
 		"""Configure accelerator group"""

--- a/sunflower/plugins/rename_extensions/default.py
+++ b/sunflower/plugins/rename_extensions/default.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import
 import re
 import os
 
-from gi.repository import Gtk
+from gi.repository import Gtk, Gdk
 from sunflower.plugin_base.rename_extension import RenameExtension
 from sunflower.gui.input_dialog import InputRangeDialog
 from sunflower.tools.advanced_rename import Column as RenameColumn
@@ -178,21 +178,7 @@ class DefaultRename(RenameExtension):
 
 	def __button_add_clicked(self, widget, data=None):
 		"""Handle clicking on add button"""
-		self._add_menu.popup(None, None, self.__get_menu_position, widget, 1, 0)
-
-	def __get_menu_position(self, menu, *args):
-		"""Get history menu position"""
-		# get coordinates
-		button = args[-1]
-		window_x, window_y = self._parent.window.get_window().get_position()
-		button_x, button_y = button.translate_coordinates(self._parent.window, 0, 0)
-		button_h = button.get_allocation().height
-
-		# calculate absolute menu position
-		pos_x = window_x + button_x
-		pos_y = window_y + button_y + button_h
-
-		return pos_x, pos_y, True
+		self._add_menu.popup_at_widget(widget, Gdk.Gravity.SOUTH_WEST, Gdk.Gravity.NORTH_WEST, None)
 
 	def __add_to_template(self, widget, type):
 		"""Add variable to template"""

--- a/sunflower/widgets/tab_label.py
+++ b/sunflower/widgets/tab_label.py
@@ -110,7 +110,7 @@ class TabLabel:
 			item = menu_manager.create_menu_item(item)
 			menu.append(item)
 
-		menu.popup(None, None, None, None, 3, 0)
+		menu.popup_at_pointer()
 		menu.show_all()
 
 	def _button_release_event(self, widget, event, data=None):


### PR DESCRIPTION
Updated deprecated menu.popup() functions. This results in simplified code, as we don't need so much calculations any more - all work is done by popup_at_widget() function. Also there should be no more issues with menus going off screen, at least in Wayland.
There is still one popup() function left not updated in indicator.py file, as it is using deprecated Gtk.StatusIcon(). I've created separate issue #467 for that discussion.