### PR TITLE
Remove deprecated set_wmclass functions

### DIFF
--- a/sunflower/gui/about_window.py
+++ b/sunflower/gui/about_window.py
@@ -63,7 +63,6 @@ class AboutWindow:
 		# configure dialog
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(parent)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		# connect signals
 		self._dialog.connect('activate-link', parent.goto_web)

--- a/sunflower/gui/error_list.py
+++ b/sunflower/gui/error_list.py
@@ -27,7 +27,6 @@ class ErrorList:
 		self._window.set_skip_taskbar_hint(False)
 		self._window.set_modal(False)
 		self._window.set_transient_for(parent.get_window())
-		self._window.set_wmclass('Sunflower', 'Sunflower')
 		self._window.set_border_width(7)
 
 		self._window.connect('key-press-event', self._handle_key_press)

--- a/sunflower/gui/history_list.py
+++ b/sunflower/gui/history_list.py
@@ -31,7 +31,6 @@ class HistoryList(Gtk.Window):
 		self.set_skip_taskbar_hint(True)
 		self.set_modal(True)
 		self.set_transient_for(application)
-		self.set_wmclass('Sunflower', 'Sunflower')
 		self.set_border_width(7)
 
 		# create UI

--- a/sunflower/gui/input_dialog.py
+++ b/sunflower/gui/input_dialog.py
@@ -37,7 +37,6 @@ class InputDialog:
 		self._dialog.set_skip_taskbar_hint(True)
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(application)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		self._container = Gtk.VBox(False, 0)
 		self._container.set_border_width(5)
@@ -570,7 +569,6 @@ class DeleteDialog:
 
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(application)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 		self._dialog.set_default_size(-1, 0)
 
 		# create user interface for operation queue
@@ -632,7 +630,6 @@ class CopyDialog:
 		self._dialog.set_skip_taskbar_hint(True)
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(application)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		# create additional components
 		vbox = Gtk.VBox(False, 0)
@@ -1051,7 +1048,6 @@ class OverwriteDialog:
 		self._dialog.set_skip_taskbar_hint(False)
 		self._dialog.set_modal(True)
 		self._dialog.set_urgency_hint(True)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		hbox = Gtk.HBox(False, 10)
 		hbox.set_border_width(10)
@@ -1326,7 +1322,6 @@ class AddBookmarkDialog:
 		self._dialog.set_skip_taskbar_hint(True)
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(application)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		# create component container
 		vbox = Gtk.VBox(False, 5)
@@ -1419,7 +1414,6 @@ class OperationError:
 		self._dialog.set_skip_taskbar_hint(True)
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(application)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		# create component container
 		hbox = Gtk.HBox(False, 10)
@@ -1503,7 +1497,6 @@ class CreateToolbarWidgetDialog:
 		self._dialog.set_skip_taskbar_hint(True)
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(application)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		# create component container
 		vbox = Gtk.VBox(False, 5)
@@ -1698,7 +1691,6 @@ class ApplicationSelectDialog:
 		self._dialog.set_skip_taskbar_hint(True)
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(application)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		self._container = Gtk.VBox(False, 5)
 		self._container.set_border_width(5)
@@ -1841,7 +1833,6 @@ class PathInputDialog():
 		self._dialog.set_skip_taskbar_hint(True)
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(application)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		self._container = Gtk.VBox(False, 0)
 		self._container.set_border_width(5)

--- a/sunflower/gui/keyring_manager_window.py
+++ b/sunflower/gui/keyring_manager_window.py
@@ -31,7 +31,6 @@ class KeyringManagerWindow:
 		self._window.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
 		self._window.set_skip_taskbar_hint(False)
 		self._window.set_modal(False)
-		self._window.set_wmclass('Sunflower', 'Sunflower')
 		self._window.set_border_width(7)
 
 		# connect signals

--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -75,7 +75,6 @@ class MainWindow(Gtk.ApplicationWindow):
 
 		# set window title
 		self.set_title(_('Sunflower'))
-		self.set_wmclass('Sunflower', 'Sunflower')
 
 		# local variables
 		self._geometry = None

--- a/sunflower/gui/preferences_window.py
+++ b/sunflower/gui/preferences_window.py
@@ -36,7 +36,6 @@ class PreferencesWindow(Gtk.Window):
 		self.set_skip_taskbar_hint(True)
 		self.set_transient_for(parent)
 		self.set_type_hint(Gdk.WindowTypeHint.DIALOG)
-		self.set_wmclass('Sunflower', 'Sunflower')
 
 		self.connect('delete_event', self._hide)
 		self.connect('key-press-event', self._handle_key_press)

--- a/sunflower/plugins/file_list/dialogs.py
+++ b/sunflower/plugins/file_list/dialogs.py
@@ -41,7 +41,6 @@ class SambaInputDialog:
 		self._dialog.set_skip_taskbar_hint(True)
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(parent)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		self._dialog.vbox.set_spacing(0)
 		self._dialog.set_default_response(Gtk.ResponseType.OK)
@@ -254,7 +253,6 @@ class FtpInputDialog:
 		self._dialog.set_skip_taskbar_hint(True)
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(parent)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		self._dialog.vbox.set_spacing(0)
 		self._dialog.set_default_response(Gtk.ResponseType.OK)
@@ -448,7 +446,6 @@ class DavInputDialog:
 		self._dialog.set_skip_taskbar_hint(True)
 		self._dialog.set_modal(True)
 		self._dialog.set_transient_for(parent)
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 
 		self._dialog.vbox.set_spacing(0)
 		self._dialog.set_default_response(Gtk.ResponseType.OK)

--- a/sunflower/tools/advanced_rename.py
+++ b/sunflower/tools/advanced_rename.py
@@ -32,7 +32,6 @@ class AdvancedRename:
 		self.window.set_transient_for(application)
 		self.window.set_border_width(7)
 		self.window.set_type_hint(Gdk.WindowTypeHint.DIALOG)
-		self.window.set_wmclass('Sunflower', 'Sunflower')
 
 		self.window.connect('key-press-event', self._handle_key_press)
 

--- a/sunflower/tools/find_files.py
+++ b/sunflower/tools/find_files.py
@@ -44,7 +44,6 @@ class FindFiles(GObject.GObject):
 		self.window.set_default_size(550, 400)
 		self.window.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
 		self.window.set_transient_for(application)
-		self.window.set_wmclass('Sunflower', 'Sunflower')
 
 		self.window.connect('key-press-event', self._handle_key_press)
 

--- a/sunflower/tools/version_check.py
+++ b/sunflower/tools/version_check.py
@@ -21,7 +21,6 @@ class VersionCheck:
 
 		# configure window
 		self._dialog.set_title(_('Version check'))
-		self._dialog.set_wmclass('Sunflower', 'Sunflower')
 		self._dialog.set_border_width(7)
 		self._dialog.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
 		self._dialog.set_resizable(False)

--- a/sunflower/tools/viewer.py
+++ b/sunflower/tools/viewer.py
@@ -58,7 +58,6 @@ class Viewer(Gtk.Window):
 		self.set_position(Gtk.WindowPosition.CENTER_ON_PARENT)
 		self.set_resizable(True)
 		self.set_skip_taskbar_hint(False)
-		self.set_wmclass('Sunflower', 'Sunflower')
 
 		header_bar = Gtk.HeaderBar.new()
 		header_bar.set_title(display_filename)


### PR DESCRIPTION
Removing deprecated set_wmclass functions as [recommended in GTK docs](https://lazka.github.io/pgi-docs/Gtk-3.0/classes/Window.html#Gtk.Window.set_wmclass):

> Don’t use this function. It sets the X Window System “class” and “name” hints for a window. According to the ICCCM, you should always set these to the same value for all windows in an application, and GTK+ sets them to that value by default, so calling this function is sort of pointless.