### PR TITLE
File List: always show emblem icons in emblem menu

### DIFF
--- a/sunflower/plugins/file_list/file_list.py
+++ b/sunflower/plugins/file_list/file_list.py
@@ -1231,6 +1231,7 @@ class FileList(ItemList):
 			# create menu item
 			menu_item = Gtk.ImageMenuItem(emblem)
 			menu_item.set_image(image)
+			menu_item.set_always_show_image(True)
 			menu_item.connect('activate', self._handle_emblem_toggle, emblem)
 
 			# add emblem to menu


### PR DESCRIPTION
Pressing Ctrl+E on any row in items list shows emblem menu. Currently only text labels are displayed (at least on my Fedora OS). This commit forces emblem icons always to be displayed.