### PR TITLE
Fix opening file from URI

### DIFF
--- a/sunflower/associations.py
+++ b/sunflower/associations.py
@@ -216,7 +216,7 @@ class AssociationManager:
 				if application.supports_uris():
 					selection = [
 						'file://{0}'.format(pathname2url(encode_file_name(path)))
-						if not path.startswith('file://') else encode_file_name(path)
+						if '://' not in path else path
 						for path in selection]
 					application.launch_uris(selection)
 				else:


### PR DESCRIPTION
My attempt to fix #419 . Only tested with FTP provider and local provider. Also tested with file names containing spaces on FTP - no problems with opening them.