### PR TITLE
Zip provider: set default permissions

### DIFF
--- a/sunflower/plugins/archive_support/zip_provider.py
+++ b/sunflower/plugins/archive_support/zip_provider.py
@@ -67,10 +67,16 @@ class ZipProvider(Provider):
 				# set fallback timestamp for files with invalid date_time value
 				file_timestamp = 0
 
+			# get permissions mode
+			mode = int(info.external_attr >> 16)
+			# set default permissions if file had none
+			if mode == 0:
+				mode = 0o644 if file_type == FileType.REGULAR else 0o775
+
 			# prepare file info
 			file_info = FileInfo(
 					size = info.file_size,
-					mode = int(info.external_attr >> 16),
+					mode = mode,
 					user_id = 0,
 					group_id = 0,
 					time_modify = file_timestamp,


### PR DESCRIPTION
Prevent unpacking files with permissions set to 0, where user will need to use sudo to remove or access them. Issue observed with "fat" type files in zip. Also fixes issue when unzip errors out after unpacking first directory and cannot write files inside due to permissions.
Default file and directory permission values where taken from Gnome Archive Manager.
Fixes #302 

I know, that this is not perfect solution, but at least it makes Sunflower inbuilt zip unpacker much more useful, for now. In the future I suppose unpacker might switch to libarchive (if user has it installed) to provide much better unpacking features support.