### PR TITLE
Advanced rename fixes

### DIFF
--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -2435,7 +2435,18 @@ class MainWindow(Gtk.ApplicationWindow):
 			active_object = self.get_active_object()
 
 			if issubclass(active_object.__class__, ItemList):
-				AdvancedRename(active_object, self)
+				if active_object._get_selection():
+					AdvancedRename(active_object, self)
+				else:
+					dialog = Gtk.MessageDialog(
+						self,
+						Gtk.DialogFlags.DESTROY_WITH_PARENT,
+						Gtk.MessageType.INFO,
+						Gtk.ButtonsType.OK,
+						_('Please select at least one file or directory.')
+					)
+					dialog.run()
+					dialog.destroy()
 
 		elif not issubclass(self._active_object.__class__, ItemList):
 			# active object is not item list

--- a/sunflower/plugins/rename_extensions/audio_metadata.py
+++ b/sunflower/plugins/rename_extensions/audio_metadata.py
@@ -77,10 +77,14 @@ class AudioMetadataRename(RenameExtension):
 
 		# create warning label
 		label_warning = Gtk.Label(label=_(
-							'In order to use this extension you need <b>mutagen</b> module installed!'
-						))
+			'In order to use this extension you need <b>mutagen</b> module installed!'
+		))
 		label_warning.set_use_markup(True)
-		label_warning.set_property('no-show-all', USE_MUTAGEN)
+
+		infobar = Gtk.InfoBar()
+		infobar.set_property('no-show-all', USE_MUTAGEN)
+		infobar_content = infobar.get_content_area()
+		infobar_content.add(label_warning)
 
 		# pack gui
 		vbox_template.pack_start(label_template, False, False, 0)
@@ -104,8 +108,8 @@ class AudioMetadataRename(RenameExtension):
 		hbox.pack_start(vbox_left, True, True, 0)
 		hbox.pack_start(vbox_right, True, True, 0)
 
+		self.vbox.pack_start(infobar, False, False, 0)
 		self.vbox.pack_start(hbox, False, False, 0)
-		self.vbox.pack_end(label_warning, False, False, 0)
 
 	def get_title(self):
 		"""Return extension title"""

--- a/sunflower/tools/advanced_rename.py
+++ b/sunflower/tools/advanced_rename.py
@@ -32,6 +32,7 @@ class AdvancedRename:
 		self.window.set_transient_for(application)
 		self.window.set_border_width(7)
 		self.window.set_type_hint(Gdk.WindowTypeHint.DIALOG)
+		self.window.set_modal(True)
 		self.window.set_wmclass('Sunflower', 'Sunflower')
 
 		self.window.connect('key-press-event', self._handle_key_press)


### PR DESCRIPTION
Few minor improvements for Advanced rename plugin. Not opening plugin window with no items selected should prevent some bug reports in the future.