### PR TITLE
Main window: Fix initial notebook focus.

### DIFF
--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -1458,7 +1458,7 @@ class MainWindow(Gtk.ApplicationWindow):
 			# focus active notebook
 			active_notebook_index = self.options.get('active_notebook')
 			notebook = (self.left_notebook, self.right_notebook)[active_notebook_index]
-			notebook.grab_focus()
+			notebook.get_nth_page(notebook.get_current_page()).focus_main_object()
 
 	def create_tab(self, notebook, plugin_class=None, options=None):
 		"""Safe create tab"""


### PR DESCRIPTION
Thank you for building and maintaining this excellent tool.

On my Ubuntu 20.04 system, Sunflower always starts with the right pane focused. It seems like `new_tab.focus_main_object()` (which happens for the right pane last) somehow overrides the later `notebook.grab_focus()`. I don’t really understand why this happens. But this PR fixes the problem for me.