### PR TITLE
Fix help for command-line arguments

### DIFF
--- a/sunflower/__main__.py
+++ b/sunflower/__main__.py
@@ -104,7 +104,7 @@ class Sunflower(Gtk.Application):
 		no_load_tabs_entry.flags = 0
 		no_load_tabs_entry.arg = GLib.OptionArg.NONE
 		no_load_tabs_entry.arg_date = None
-		no_load_tabs_entry.description = _('Skip loading additional plugins')
+		no_load_tabs_entry.description = _('Skip loading additional tabs')
 		no_load_tabs_entry.arg_description = None
 
 		left_tab_entry = GLib.OptionEntry()
@@ -114,7 +114,7 @@ class Sunflower(Gtk.Application):
 		left_tab_entry.arg = GLib.OptionArg.STRING_ARRAY
 		left_tab_entry.arg_date = None
 		left_tab_entry.description = _('Open new tab on the left notebook')
-		left_tab_entry.arg_description = None
+		left_tab_entry.arg_description = _('DIRECTORY')
 
 		right_tab_entry = GLib.OptionEntry()
 		right_tab_entry.long_name = 'right-tab'
@@ -123,7 +123,7 @@ class Sunflower(Gtk.Application):
 		right_tab_entry.arg = GLib.OptionArg.STRING_ARRAY
 		right_tab_entry.arg_date = None
 		right_tab_entry.description = _('Open new tab on the right notebook')
-		right_tab_entry.arg_description = None
+		right_tab_entry.arg_description = _('DIRECTORY')
 
 		left_terminal_entry = GLib.OptionEntry()
 		left_terminal_entry.long_name = 'left-terminal'
@@ -132,7 +132,7 @@ class Sunflower(Gtk.Application):
 		left_terminal_entry.arg = GLib.OptionArg.STRING_ARRAY
 		left_terminal_entry.arg_date = None
 		left_terminal_entry.description = _('Open terminal tab on the left notebook')
-		left_terminal_entry.arg_description = None
+		left_terminal_entry.arg_description = _('DIRECTORY')
 
 		right_terminal_entry = GLib.OptionEntry()
 		right_terminal_entry.long_name = 'right-terminal'
@@ -141,7 +141,7 @@ class Sunflower(Gtk.Application):
 		right_terminal_entry.arg = GLib.OptionArg.STRING_ARRAY
 		right_terminal_entry.arg_date = None
 		right_terminal_entry.description = _('Open terminal tab on the right notebook')
-		right_terminal_entry.arg_description = None
+		right_terminal_entry.arg_description = _('DIRECTORY')
 
 		option_entries = [
 				version_entry, no_plugins_entry, no_load_tabs_entry,


### PR DESCRIPTION
It wasn’t obvious to me that I could pass arguments to those options until I saw it in the source code.