### PR TITLE
File list: Fix Gtk.MessageDialog transient_for.

### DIFF
--- a/sunflower/plugin_base/item_list.py
+++ b/sunflower/plugin_base/item_list.py
@@ -643,7 +643,7 @@ class ItemList(PluginBase):
 		else:
 			# invalid path, notify user
 			dialog = Gtk.MessageDialog(
-									self,
+									self._parent,
 									Gtk.DialogFlags.DESTROY_WITH_PARENT,
 									Gtk.MessageType.ERROR,
 									Gtk.ButtonsType.OK,

--- a/sunflower/plugins/file_list/file_list.py
+++ b/sunflower/plugins/file_list/file_list.py
@@ -1008,7 +1008,7 @@ class FileList(ItemList):
 				except IOError as error:
 					# problem renaming item
 					dialog = Gtk.MessageDialog(
-											self,
+											self._parent,
 											Gtk.DialogFlags.DESTROY_WITH_PARENT,
 											Gtk.MessageType.ERROR,
 											Gtk.ButtonsType.OK,


### PR DESCRIPTION
Fixes #502, as well as another similar instance I spotted. However, I didn’t attempt to find all instances of this or similar bugs.