### PR TITLE
File list: Make executing files optional.

### DIFF
--- a/sunflower/associations.py
+++ b/sunflower/associations.py
@@ -12,6 +12,7 @@ from sunflower.parameters import Parameters
 from sunflower.plugin_base.provider import Mode
 from sunflower.plugin_base.terminal import TerminalType
 from sunflower.gui.input_dialog import ApplicationSelectDialog
+from sunflower.gui.preferences.item_list import ExecutableAction
 
 
 ApplicationInfo = namedtuple(
@@ -277,6 +278,7 @@ class AssociationManager:
 		"""Execute specified item properly."""
 		mime_type = self.get_mime_type(path)
 		terminal_type = self._application.options.section('terminal').get('type')
+		executable_action = self._application.options.section('item_list').get('executable_action')
 		should_execute = False
 
 		if provider is not None and provider.is_local:
@@ -288,6 +290,9 @@ class AssociationManager:
 			if self.is_mime_type_unknown(mime_type):
 				data = self.get_sample_data(path, provider)
 				mime_type = self.get_mime_type(data=data)
+
+		if executable_action != ExecutableAction.EXECUTE:
+			should_execute = False
 
 		if Gio.content_type_can_be_executable(mime_type) and should_execute:
 			# file type is executable

--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -1883,6 +1883,7 @@ class MainWindow(Gtk.ApplicationWindow):
 					'number_sensitive_sort': False,
 					'right_click_select': False,
 					'single_click_navigation': False,
+					'executable_action': 0,
 					'headers_visible': True,
 					'mode_format': 1,
 					'left_directories': [],

--- a/sunflower/gui/preferences/item_list.py
+++ b/sunflower/gui/preferences/item_list.py
@@ -30,6 +30,11 @@ class Source:
 	CUSTOM = 2
 
 
+class ExecutableAction:
+	EXECUTE = 0
+	OPEN = 1
+
+
 class ItemListOptions(SettingsPage):
 	"""Options related to item lists"""
 
@@ -82,6 +87,16 @@ class ItemListOptions(SettingsPage):
 		self._combobox_mode_format.connect('changed', self._parent.enable_save)
 		self._combobox_mode_format.append(str(AccessModeFormat.OCTAL), _('Octal'))
 		self._combobox_mode_format.append(str(AccessModeFormat.TEXTUAL), _('Textual'))
+
+		# action when executable files are activated
+		hbox_executable_action = Gtk.HBox(False, 5)
+		label_executable_action = Gtk.Label(label=_('Action on executable files:'))
+		label_executable_action.set_alignment(0, 0.5)
+
+		self._combobox_executable_action = Gtk.ComboBoxText.new()
+		self._combobox_executable_action.connect('changed', self._parent.enable_save)
+		self._combobox_executable_action.append(str(ExecutableAction.EXECUTE), _('Run them'))
+		self._combobox_executable_action.append(str(ExecutableAction.OPEN), _('Open them'))
 
 		# grid lines
 		hbox_grid_lines = Gtk.HBox(False, 5)
@@ -357,6 +372,9 @@ class ItemListOptions(SettingsPage):
 		hbox_mode_format.pack_start(label_mode_format, False, False, 0)
 		hbox_mode_format.pack_start(self._combobox_mode_format, False, False, 0)
 
+		hbox_executable_action.pack_start(label_executable_action, False, False, 0)
+		hbox_executable_action.pack_start(self._combobox_executable_action, False, False, 0)
+
 		hbox_grid_lines.pack_start(label_grid_lines, False, False, 0)
 		hbox_grid_lines.pack_start(self._combobox_grid_lines, False, False, 0)
 
@@ -380,6 +398,7 @@ class ItemListOptions(SettingsPage):
 		vbox_operation.pack_start(self._checkbox_single_click, False, False, 0)
 		vbox_operation.pack_start(self._checkbox_right_click, False, False, 0)
 		vbox_operation.pack_start(self._checkbox_second_extension, False, False, 0)
+		vbox_operation.pack_start(hbox_executable_action, False, False, 5)
 		vbox_operation.pack_start(hbox_quick_search, False, False, 5)
 		vbox_operation.pack_start(vbox_time_format, False, False, 5)
 
@@ -645,6 +664,7 @@ class ItemListOptions(SettingsPage):
 		self._checkbox_case_sensitive.set_active(section.get('case_sensitive_sort'))
 		self._checkbox_number_sensitive.set_active(section.get('number_sensitive_sort'))
 		self._checkbox_single_click.set_active(section.get('single_click_navigation'))
+		self._combobox_executable_action.set_active(section.get('executable_action'))
 		self._checkbox_right_click.set_active(section.get('right_click_select'))
 		self._checkbox_show_headers.set_active(section.get('headers_visible'))
 		self._checkbox_media_preview.set_active(options.get('media_preview'))
@@ -696,6 +716,7 @@ class ItemListOptions(SettingsPage):
 		section.set('case_sensitive_sort', self._checkbox_case_sensitive.get_active())
 		section.set('number_sensitive_sort', self._checkbox_number_sensitive.get_active())
 		section.set('single_click_navigation', self._checkbox_single_click.get_active())
+		section.set('executable_action', self._combobox_executable_action.get_active())
 		section.set('right_click_select', self._checkbox_right_click.get_active())
 		section.set('headers_visible', self._checkbox_show_headers.get_active())
 		options.set('media_preview', self._checkbox_media_preview.get_active())


### PR DESCRIPTION
I have many executable shell and Python scripts. When I activate them in a file manager, I always want to open them as text files, never to execute them. I like how GNOME Files handles this: it has an option to always execute, always open, or ask every time. This commit adds a similar option to Sunflower, except that “ask every time” is not yet implemented (because I don’t need it) — but it should be easy to add later.