### PR TITLE
File list, Properties Window: Change owner/user column type to str.

### DIFF
--- a/sunflower/gui/properties_window.py
+++ b/sunflower/gui/properties_window.py
@@ -582,7 +582,7 @@ class PropertiesWindow(Gtk.Window):
 		table_ownership.attach(label, 0, 1, 1, 2)
 
 		# create owner combobox
-		self._list_owner = Gtk.ListStore(str, int)
+		self._list_owner = Gtk.ListStore(str, GObject.TYPE_INT64)
 		cell_owner = Gtk.CellRendererText()
 
 		self._combobox_owner = Gtk.ComboBox.new_with_model(self._list_owner)
@@ -593,7 +593,7 @@ class PropertiesWindow(Gtk.Window):
 		table_ownership.attach(self._combobox_owner, 1, 2, 0, 1)
 
 		# create group combobox
-		self._list_group = Gtk.ListStore(str, int)
+		self._list_group = Gtk.ListStore(str, GObject.TYPE_INT64)
 		cell_group = Gtk.CellRendererText()
 
 		self._combobox_group = Gtk.ComboBox.new_with_model(self._list_group)

--- a/sunflower/plugins/file_list/file_list.py
+++ b/sunflower/plugins/file_list/file_list.py
@@ -95,8 +95,8 @@ class FileList(ItemList):
 								str,	# Column.COLOR
 								str,	# Column.ICON
 								bool,	# Column.SELECTED
-								int,	# Column.USER_ID
-								int,	# Column.GROUP_ID
+								GObject.TYPE_INT64,	# Column.USER_ID
+								GObject.TYPE_INT64,	# Column.GROUP_ID
 								GObject.TYPE_PYOBJECT,	# Column.EMBLEMS
 								str		# Column.SORT_DATA
 							)


### PR DESCRIPTION
UserId and GroupId are _uint32_ and python pwd return _int_ values from -1 to 4294967294
While Gtk converts pythons _int_ to _signed int32_, so we get OverflowError when gtk puts these values to int column
I suggest using _str_ type just to display these columns

maybe related to https://github.com/MeanEYE/Sunflower/issues/509