### PR TITLE
Fix missing icon for desktop file (#477)

### DIFF
--- a/Sunflower.desktop
+++ b/Sunflower.desktop
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3 -m sunflower
 [Desktop Entry]
 Type=Application
-Icon=sunflower
+Icon=/usr/share/sunflower/images/sunflower.svg
 Name=Sunflower
 StartupWMClass=Sunflower
 GenericName=File Manager


### PR DESCRIPTION
The path to the application icon is incorrectly specified in the Sunflower.desctop file. This commit fixes that.