### PR TITLE
Add shortcuts to the command bar (priority to function key shortcuts)

### DIFF
--- a/sunflower/gui/main_window.py
+++ b/sunflower/gui/main_window.py
@@ -425,18 +425,20 @@ class MainWindow(Gtk.ApplicationWindow):
 		self.command_bar.set_border_width(2)
 
 		buttons = (
-				(_('Refresh'), _('Reload active item list'), self._command_reload),
-				(_('Rename'), _('Rename selected file'), self._command_rename),
-				(_('Preview'), _('Preview selected file'), self._command_view),
-				(_('Edit'), _('Edit selected file'), self._command_edit),
-				(_('Copy'), _('Copy selected items from active to opposite list'), self._command_copy),
-				(_('Move'), _('Move selected items from active to opposite list'), self._command_move),
-				(_('Create'), _('Create new directory'), self._command_create),
-				(_('Delete'), _('Delete selected items'), self._command_delete)
+				(_('Refresh'), _('Reload active item list'), self._command_reload, 'item_list', 'refresh_list'),
+				(_('Rename'), _('Rename selected file'), self._command_rename, 'item_list', 'rename_file'),
+				(_('Preview'), _('Preview selected file'), self._command_view, 'item_list', 'view_selected'),
+				(_('Edit'), _('Edit selected file'), self._command_edit, 'item_list', 'edit_selected'),
+				(_('Copy'), _('Copy selected items from active to opposite list'), self._command_copy, 'item_list', 'copy_files'),
+				(_('Move'), _('Move selected items from active to opposite list'), self._command_move, 'item_list', 'move_files'),
+				(_('Create'), _('Create new directory'), self._command_create, 'main_menu', 'create_directory'),
+				(_('Delete'), _('Delete selected items'), self._command_delete, 'item_list', 'delete_files')
 				)
 
+		self._command_bar_buttons = []
+
 		# create buttons and pack them
-		for text, tooltip, callback in buttons:
+		for text, tooltip, callback, accel_group, accel_name in buttons:
 			button = Gtk.Button(label=text)
 
 			if callback is not None:
@@ -449,7 +451,18 @@ class MainWindow(Gtk.ApplicationWindow):
 			button.show()  # we need to explicitly show in cases where toolbar is not visible
 			self.command_bar.pack_start(button, True, True, 0)
 
+			# store button info for label updates
+			self._command_bar_buttons.append({
+				'button': button,
+				'label': text,
+				'accel_group': accel_group,
+				'accel_name': accel_name
+			})
+
 		self.command_bar.set_property('no-show-all', not self.options.get('show_command_bar'))
+
+		# update button labels based on initial settings
+		self._update_command_bar_labels()
 
 		# pack user interface
 		vbox = Gtk.VBox(False, 0)
@@ -507,6 +520,42 @@ class MainWindow(Gtk.ApplicationWindow):
 
 		# show widgets
 		self.show_all()
+
+	def _update_command_bar_labels(self):
+		"""Update command bar button labels to optionally include shortcuts."""
+		show_shortcuts = self.options.get('show_command_bar_shortcuts')
+
+		for button_info in self._command_bar_buttons:
+			button = button_info['button']
+			base_label = button_info['label']
+
+			if show_shortcuts:
+				group = button_info['accel_group']
+				name = button_info['accel_name']
+
+				# Get both primary and secondary accelerators
+				primary_accel = self.accelerator_manager.get_accelerator(group, name, primary=True)
+				secondary_accel = self.accelerator_manager.get_accelerator(group, name, primary=False)
+
+				# Prefer function key (F1-F12) if available, matching Norton Commander tradition
+				accel = None
+				if primary_accel and primary_accel[0] > 0:
+					if Gdk.KEY_F1 <= primary_accel[0] <= Gdk.KEY_F12:
+						accel = primary_accel
+					elif secondary_accel and secondary_accel[0] > 0 and Gdk.KEY_F1 <= secondary_accel[0] <= Gdk.KEY_F12:
+						accel = secondary_accel
+					else:
+						accel = primary_accel  # fallback to primary
+				elif secondary_accel and secondary_accel[0] > 0:
+					accel = secondary_accel
+
+				if accel:
+					shortcut = Gtk.accelerator_get_label(accel[0], accel[1])
+					button.set_label('{} ({})'.format(base_label, shortcut))
+				else:
+					button.set_label(base_label)
+			else:
+				button.set_label(base_label)
 
 	def _destroy(self, widget=None, data=None):
 		"""Application destructor"""
@@ -1952,6 +2001,7 @@ class MainWindow(Gtk.ApplicationWindow):
 					'show_toolbar': False,
 					'show_titlebar': True,
 					'show_command_bar': False,
+					'show_command_bar_shortcuts': False,  # TODO: Consider defaulting to True in future
 					'history_file': '.bash_history',
 					'last_version': 0,
 					'focus_new_tab': True,
@@ -2189,6 +2239,9 @@ class MainWindow(Gtk.ApplicationWindow):
 			# call plugin apply_settings
 			if hasattr(page, 'apply_settings'):
 				page.apply_settings()
+
+		# update command bar button labels
+		self._update_command_bar_labels()
 
 	def register_class(self, name, title, PluginClass):
 		"""Register plugin class

--- a/sunflower/gui/preferences/display.py
+++ b/sunflower/gui/preferences/display.py
@@ -38,6 +38,8 @@ class DisplayOptions(SettingsPage):
 		self._checkbox_show_toolbar.connect('toggled', self._parent.enable_save)
 		self._checkbox_show_titlebar.connect('toggled', self._parent.enable_save)
 		self._checkbox_show_command_bar.connect('toggled', self._parent.enable_save)
+		self._checkbox_show_command_bar_shortcuts = Gtk.CheckButton(_('Show keyboard shortcuts on command bar buttons'))
+		self._checkbox_show_command_bar_shortcuts.connect('toggled', self._parent.enable_save)
 		self._checkbox_horizontal_split.connect('toggled', self._parent.enable_save)
 		self._checkbox_dark_theme.connect('toggled', self._parent.enable_save)
 
@@ -136,6 +138,7 @@ class DisplayOptions(SettingsPage):
 		vbox_main_window.pack_start(self._checkbox_show_toolbar, False, False, 0)
 		vbox_main_window.pack_start(self._checkbox_show_titlebar, False, False, 0)
 		vbox_main_window.pack_start(self._checkbox_show_command_bar, False, False, 0)
+		vbox_main_window.pack_start(self._checkbox_show_command_bar_shortcuts, False, False, 0)
 		vbox_main_window.pack_start(self._checkbox_horizontal_split, False, False, 0)
 		vbox_main_window.pack_start(self._checkbox_dark_theme, False, False, 0)
 
@@ -161,6 +164,7 @@ class DisplayOptions(SettingsPage):
 		self._checkbox_show_toolbar.set_active(options.get('show_toolbar'))
 		self._checkbox_show_titlebar.set_active(options.get('show_titlebar'))
 		self._checkbox_show_command_bar.set_active(options.get('show_command_bar'))
+		self._checkbox_show_command_bar_shortcuts.set_active(options.get('show_command_bar_shortcuts'))
 		self._checkbox_tab_close_button.set_active(options.get('tab_close_button'))
 		self._checkbox_always_show_tabs.set_active(options.get('always_show_tabs'))
 		self._checkbox_superuser_notification.set_active(options.get('superuser_notification'))
@@ -184,6 +188,7 @@ class DisplayOptions(SettingsPage):
 		options.set('show_toolbar', self._checkbox_show_toolbar.get_active())
 		options.set('show_titlebar', self._checkbox_show_titlebar.get_active())
 		options.set('show_command_bar', self._checkbox_show_command_bar.get_active())
+		options.set('show_command_bar_shortcuts', self._checkbox_show_command_bar_shortcuts.get_active())
 		options.set('tab_close_button', self._checkbox_tab_close_button.get_active())
 		options.set('always_show_tabs', self._checkbox_always_show_tabs.get_active())
 		options.set('superuser_notification', self._checkbox_superuser_notification.get_active())


### PR DESCRIPTION
# Add Configurable Display of Keyboard Shortcuts on Command Bar Buttons

**WARNING:** written by AI, but under strict guidance to do the minimal best-practice changes with respect for the existing code, verify heavily, etc., and briefly reviewed by myself.

## Overview

This PR adds a new feature to the Sunflower file manager that allows users to display keyboard shortcuts on the command bar buttons, similar to how the action buttons are displayed at the bottom of Norton Commander and Midnight Commander.

Fixes: #120 

## Screenshot
<img width="1296" height="835" alt="image" src="https://github.com/user-attachments/assets/4320653f-39e1-443d-a671-ad0dad388ae4" />

## What does this change do?
- Adds a checkbox setting "Show keyboard shortcuts on command bar buttons" in the Display preferences
- When enabled, command bar buttons show labels like "Copy (F5)" instead of just "Copy"
- Uses the actual configured shortcuts dynamically, so custom shortcut changes are reflected
- Labels update when preferences are saved
- **Prioritizes function keys (F1-F12)** for display when multiple shortcuts are configured, matching Norton Commander tradition, and attempting to consistency and the faster keys in the command bar.

## Why is this useful?
This improves user safety by allowing users to easily verify which keyboard shortcut corresponds to each button, reducing the chance of accidental operations. Personally, even though some of the shortcuts are in muscle memory, I always want to look at the command bar and verify the short cut before starting a bunch of operations, as the Copy/Delete/Move function keys can be "a little close" at the best of times ;) This is especially true when adopting a new file manager for the first time. #120 suggests that other users feel the same way.

## Files Changed
1. **`sunflower/gui/main_window.py`**
   - Added `_command_bar_buttons` list to track button references with accelerator mappings
   - Added `_update_command_bar_labels()` method to update button labels with function key prioritization
   - Added `show_command_bar_shortcuts` config option (default: False)
   - Integrated label updates in `apply_settings()`

2. **`sunflower/gui/preferences/display.py`**
   - Added checkbox widget for the setting
   - Added load/save handlers for the option

## Default Behaviour
The feature is disabled by default to preserve existing behaviour.

**NOTE:** I'll be submitting a separate, second PR on top of this to enable by default, so that can be easily rejected independently, if necessary.
